### PR TITLE
feat(api): unify v2 error envelope and auth patterns (PR1 of API hygiene)

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -584,8 +584,16 @@ export interface components {
             /** Tags */
             tags: string[];
         };
-        /** AreaCreateError */
-        AreaCreateError: {
+        /**
+         * DetailErrorOut
+         * @description Single-message error envelope.
+         *
+         *     Used for all 4xx responses that do not carry per-field validation details.
+         *     Equivalent in shape to django-ninja's default error body, made explicit so
+         *     every endpoint declares it in its `response={...}` map and it appears in
+         *     the OpenAPI schema.
+         */
+        DetailErrorOut: {
             /** Detail */
             detail: string;
         };
@@ -606,11 +614,6 @@ export interface components {
             geojson?: {
                 [key: string]: unknown;
             } | null;
-        };
-        /** AreaDeleteError */
-        AreaDeleteError: {
-            /** Detail */
-            detail: string;
         };
         /** BasisOfRecordOut */
         BasisOfRecordOut: {
@@ -860,8 +863,18 @@ export interface components {
             /** Vernacularname */
             vernacularName: string;
         };
-        /** AlertValidationErrorOut */
-        AlertValidationErrorOut: {
+        /**
+         * ValidationErrorOut
+         * @description Field-validation error envelope.
+         *
+         *     Used for 422 responses that carry per-field error messages. The top-level
+         *     `detail` lets clients display a generic message when they don't iterate
+         *     per-field; `errors` is a map of field name to a list of validation
+         *     messages for that field.
+         */
+        ValidationErrorOut: {
+            /** Detail */
+            detail: string;
             /** Errors */
             errors: {
                 [key: string]: string[];
@@ -902,24 +915,12 @@ export interface components {
             /** Username */
             username: string;
         };
-        /** AuthErrorOut */
-        AuthErrorOut: {
-            /** Detail */
-            detail: string;
-        };
         /** SignInIn */
         SignInIn: {
             /** Username */
             username: string;
             /** Password */
             password: string;
-        };
-        /** AuthValidationErrorOut */
-        AuthValidationErrorOut: {
-            /** Errors */
-            errors: {
-                [key: string]: string[];
-            };
         };
         /** SignUpIn */
         SignUpIn: {
@@ -1090,7 +1091,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AreaCreateError"];
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1147,7 +1148,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AreaCreateError"];
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1176,7 +1177,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AreaDeleteError"];
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1211,7 +1212,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AreaCreateError"];
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1555,7 +1556,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AlertValidationErrorOut"];
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };
@@ -1612,7 +1613,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AlertValidationErrorOut"];
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };
@@ -1689,7 +1690,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthErrorOut"];
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1722,7 +1723,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthValidationErrorOut"];
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };
@@ -1753,7 +1754,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthValidationErrorOut"];
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };
@@ -1824,7 +1825,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthValidationErrorOut"];
+                    "application/json": components["schemas"]["ValidationErrorOut"];
                 };
             };
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -24,8 +24,6 @@ from dashboard.api_v2_schemas import (
     AlertNotificationFrequencyOut,
     AlertOut,
     AlertValidationErrorOut,
-    AreaCreateError,
-    AreaDeleteError,
     AreaFromDrawingIn,
     AreaOut,
     AreaPatchIn,
@@ -36,6 +34,7 @@ from dashboard.api_v2_schemas import (
     CommentOut,
     DataImportOut,
     DatasetOut,
+    DetailErrorOut,
     FiltersQuery,
     HistogramEntryOut,
     ObservationDetailOut,
@@ -149,7 +148,7 @@ def area_geojson(request: HttpRequest, area_id: int):
 
 @api_v2.post(
     "/areas/",
-    response={201: AreaOut, 422: AreaCreateError},
+    response={201: AreaOut, 422: DetailErrorOut},
     auth=django_auth,
 )
 def area_create(
@@ -184,7 +183,7 @@ def area_create(
 
 @api_v2.post(
     "/areas/from-drawing/",
-    response={201: AreaOut, 422: AreaCreateError},
+    response={201: AreaOut, 422: DetailErrorOut},
     auth=django_auth,
 )
 def area_create_from_drawing(request: HttpRequest, payload: AreaFromDrawingIn):
@@ -211,7 +210,7 @@ def area_create_from_drawing(request: HttpRequest, payload: AreaFromDrawingIn):
 
 @api_v2.patch(
     "/areas/{area_id}/",
-    response={200: AreaOut, 422: AreaCreateError},
+    response={200: AreaOut, 422: DetailErrorOut},
     auth=django_auth,
 )
 def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
@@ -239,7 +238,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
 
 @api_v2.delete(
     "/areas/{area_id}/",
-    response={204: None, 409: AreaDeleteError},
+    response={204: None, 409: DetailErrorOut},
     auth=django_auth,
 )
 def area_delete_endpoint(request: HttpRequest, area_id: int):

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -26,7 +26,6 @@ from dashboard.api_v2_schemas import (
     AreaFromDrawingIn,
     AreaOut,
     AreaPatchIn,
-    AuthValidationErrorOut,
     BasisOfRecordOut,
     CommentIn,
     CommentOut,
@@ -802,7 +801,7 @@ def auth_signin(request: HttpRequest, payload: SignInIn):
 
 @api_v2.post(
     "/auth/signup/",
-    response={201: SignInOut, 422: AuthValidationErrorOut},
+    response={201: SignInOut, 422: ValidationErrorOut},
     auth=None,
 )
 def auth_signup(request: HttpRequest, payload: SignUpIn):
@@ -822,7 +821,7 @@ def auth_signup(request: HttpRequest, payload: SignUpIn):
         errors: dict[str, list[str]] = {
             field: [str(msg) for msg in msgs] for field, msgs in form.errors.items()
         }
-        return 422, {"errors": errors}
+        return 422, {"detail": "Validation failed", "errors": errors}
     user = form.save()
     login(request, user)
     return 201, {"username": user.get_username()}
@@ -830,7 +829,7 @@ def auth_signup(request: HttpRequest, payload: SignUpIn):
 
 @api_v2.post(
     "/auth/password-change/",
-    response={204: None, 422: AuthValidationErrorOut},
+    response={204: None, 422: ValidationErrorOut},
     auth=django_auth,
 )
 def auth_password_change(request: HttpRequest, payload: PasswordChangeIn):
@@ -838,11 +837,13 @@ def auth_password_change(request: HttpRequest, payload: PasswordChangeIn):
     user = cast(User, request.user)
     if not user.check_password(payload.old_password):
         return 422, {
-            "errors": {"old_password": [str(_("The old password is incorrect."))]}
+            "detail": "Validation failed",
+            "errors": {"old_password": [str(_("The old password is incorrect."))]},
         }
     if payload.new_password1 != payload.new_password2:
         return 422, {
-            "errors": {"new_password2": [str(_("The two passwords do not match."))]}
+            "detail": "Validation failed",
+            "errors": {"new_password2": [str(_("The two passwords do not match."))]},
         }
     user.set_password(payload.new_password1)
     user.save()
@@ -884,7 +885,7 @@ def profile_get(request: HttpRequest):
 
 @api_v2.put(
     "/profile/",
-    response={200: ProfileOut, 422: AuthValidationErrorOut},
+    response={200: ProfileOut, 422: ValidationErrorOut},
     auth=django_auth,
 )
 def profile_put(request: HttpRequest, payload: ProfileIn):
@@ -893,11 +894,12 @@ def profile_put(request: HttpRequest, payload: ProfileIn):
     # Validate unique email (excluding self)
     if User.objects.filter(email=payload.email).exclude(pk=user.pk).exists():
         return 422, {
-            "errors": {"email": [str(_("This email address is already in use."))]}
+            "detail": "Validation failed",
+            "errors": {"email": [str(_("This email address is already in use."))]},
         }
     valid_units = ("days", "weeks", "months", "years")
     if payload.delayUnit not in valid_units:
-        return 422, {"errors": {"delayUnit": ["Invalid unit."]}}
+        return 422, {"detail": "Validation failed", "errors": {"delayUnit": ["Invalid unit."]}}
     user.first_name = payload.firstName
     user.last_name = payload.lastName
     user.email = payload.email

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -23,7 +23,6 @@ from dashboard.api_v2_schemas import (
     AlertIn,
     AlertNotificationFrequencyOut,
     AlertOut,
-    AlertValidationErrorOut,
     AreaFromDrawingIn,
     AreaOut,
     AreaPatchIn,
@@ -45,6 +44,7 @@ from dashboard.api_v2_schemas import (
     SignInOut,
     SignUpIn,
     SpeciesOut,
+    ValidationErrorOut,
 )
 from dashboard.forms import SignUpForm, _days_to_value_unit, _value_unit_to_days
 from dashboard.geo_utils import file_to_wkt_multipolygon, geojson_to_multipolygon
@@ -724,14 +724,14 @@ def alerts_list(request: HttpRequest):
 
 
 @api_v2.post(
-    "/alerts/", response={201: AlertOut, 422: AlertValidationErrorOut}, auth=django_auth
+    "/alerts/", response={201: AlertOut, 422: ValidationErrorOut}, auth=django_auth
 )
 def alert_create(request: HttpRequest, payload: AlertIn):
     """Create a new alert for the authenticated user."""
     alert = Alert(user=cast(User, request.user))
     errors = _save_alert(alert, payload)
     if errors:
-        return 422, {"errors": errors}
+        return 422, {"detail": "Validation failed", "errors": errors}
     return 201, _alert_to_out(alert)
 
 
@@ -750,7 +750,7 @@ def alert_detail(request: HttpRequest, alert_id: int):
 
 @api_v2.put(
     "/alerts/{alert_id}/",
-    response={200: AlertOut, 422: AlertValidationErrorOut},
+    response={200: AlertOut, 422: ValidationErrorOut},
     auth=django_auth,
 )
 def alert_update(request: HttpRequest, alert_id: int, payload: AlertIn):
@@ -764,7 +764,7 @@ def alert_update(request: HttpRequest, alert_id: int, payload: AlertIn):
     )
     errors = _save_alert(alert, payload)
     if errors:
-        return 422, {"errors": errors}
+        return 422, {"detail": "Validation failed", "errors": errors}
     return 200, _alert_to_out(alert)
 
 

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -595,11 +595,12 @@ def page_fragment(request: HttpRequest, identifier: str):
     return {"html": html}
 
 
-@api_v2.post("/observations/{stable_id}/mark-unseen/", response={200: dict, 403: dict})
+@api_v2.post(
+    "/observations/{stable_id}/mark-unseen/",
+    response={200: dict, 403: dict},
+    auth=django_auth,
+)
 def observation_mark_unseen(request: HttpRequest, stable_id: str):
-    if not request.user.is_authenticated:
-        raise HttpError(403, _("Authentication required"))
-
     try:
         obs = Observation.objects.get(stable_id=stable_id)
     except Observation.DoesNotExist:

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -553,6 +553,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
     auth=django_auth,
 )
 def observation_add_comment(request: HttpRequest, stable_id: str, payload: CommentIn):
+    user = cast(User, request.user)
     try:
         obs = Observation.objects.get(stable_id=stable_id)
     except Observation.DoesNotExist:
@@ -564,13 +565,13 @@ def observation_add_comment(request: HttpRequest, stable_id: str, payload: Comme
 
     comment = ObservationComment.objects.create(
         observation=obs,
-        author=request.user,
+        author=user,
         text=text,
     )
 
     return {
         "id": comment.pk,
-        "authorUsername": request.user.username,
+        "authorUsername": user.username,
         "createdAt": comment.created_at,
         "text": comment.text,
         "deletedBecauseAuthorDeleted": False,

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -27,7 +27,6 @@ from dashboard.api_v2_schemas import (
     AreaFromDrawingIn,
     AreaOut,
     AreaPatchIn,
-    AuthErrorOut,
     AuthValidationErrorOut,
     BasisOfRecordOut,
     CommentIn,
@@ -789,7 +788,7 @@ def alert_as_filters_v2(request: HttpRequest, alert_id: int):
 
 @api_v2.post(
     "/auth/signin/",
-    response={200: SignInOut, 401: AuthErrorOut},
+    response={200: SignInOut, 401: DetailErrorOut},
     auth=None,
 )
 def auth_signin(request: HttpRequest, payload: SignInIn):

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -550,11 +550,12 @@ def observation_detail(request: HttpRequest, stable_id: str):
     }
 
 
-@api_v2.post("/observations/{stable_id}/comments/", response=CommentOut)
+@api_v2.post(
+    "/observations/{stable_id}/comments/",
+    response=CommentOut,
+    auth=django_auth,
+)
 def observation_add_comment(request: HttpRequest, stable_id: str, payload: CommentIn):
-    if not request.user.is_authenticated:
-        raise HttpError(403, _("Authentication required"))
-
     try:
         obs = Observation.objects.get(stable_id=stable_id)
     except Observation.DoesNotExist:

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -170,18 +170,6 @@ class AlertOut(Schema):
     lastEmailSentOn: datetime.datetime | None
 
 
-class AlertValidationErrorOut(Schema):
-    errors: dict[str, list[str]]
-
-
-class AreaCreateError(Schema):
-    detail: str
-
-
-class AreaDeleteError(Schema):
-    detail: str
-
-
 class AreaFromDrawingIn(Schema):
     name: str
     geojson: dict  # GeoJSON FeatureCollection, EPSG:4326
@@ -215,14 +203,6 @@ class PasswordChangeIn(Schema):
     old_password: str
     new_password1: str
     new_password2: str
-
-
-class AuthErrorOut(Schema):
-    detail: str
-
-
-class AuthValidationErrorOut(Schema):
-    errors: dict[str, list[str]]
 
 
 class ProfileOut(Schema):

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -242,3 +242,28 @@ class ProfileIn(Schema):
     language: str
     delayValue: int
     delayUnit: str
+
+
+class DetailErrorOut(Schema):
+    """Single-message error envelope.
+
+    Used for all 4xx responses that do not carry per-field validation details.
+    Equivalent in shape to django-ninja's default error body, made explicit so
+    every endpoint declares it in its `response={...}` map and it appears in
+    the OpenAPI schema.
+    """
+
+    detail: str
+
+
+class ValidationErrorOut(Schema):
+    """Field-validation error envelope.
+
+    Used for 422 responses that carry per-field error messages. The top-level
+    `detail` lets clients display a generic message when they don't iterate
+    per-field; `errors` is a map of field name to a list of validation
+    messages for that field.
+    """
+
+    detail: str
+    errors: dict[str, list[str]]

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -991,6 +991,24 @@ def test_observation_add_comment_anonymous_returns_401(client, observation_detai
     assert resp.status_code == 401
 
 
+def test_observation_mark_unseen_anonymous_returns_401(client, observation_detail_data):
+    """Anonymous users get 401 from mark-unseen, not 403."""
+    obs = observation_detail_data["obs"]
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-unseen/")
+    assert resp.status_code == 401
+
+
+def test_observation_mark_unseen_no_matching_alert_returns_403(
+    client, observation_detail_data
+):
+    """Authenticated user with no matching alert cannot mark unseen: 403."""
+    user = observation_detail_data["user"]
+    obs = observation_detail_data["obs"]
+    client.force_login(user)
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-unseen/")
+    assert resp.status_code == 403
+
+
 # ---------------------------------------------------------------------------
 # ApiV2ObservationsMunicipalityVerifiedSortTests fixtures
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1180,7 +1180,9 @@ def test_alert_create_no_species_returns_422(client, alert_data):
     payload = json.dumps({"name": "Bad alert", "speciesIds": []})
     response = client.post("/api/v2/alerts/", payload, content_type="application/json")
     assert response.status_code == 422
-    assert "species" in response.json()["errors"]
+    data = response.json()
+    assert data["detail"] == "Validation failed"
+    assert "species" in data["errors"]
 
 
 def test_alert_create_requires_auth(client, alert_data):
@@ -1316,6 +1318,7 @@ def test_alert_create_duplicate_name_returns_422(client, alert_data):
     response = client.post("/api/v2/alerts/", payload, content_type="application/json")
     assert response.status_code == 422
     data = response.json()
+    assert data["detail"] == "Validation failed"
     assert "errors" in data
 
 
@@ -1333,7 +1336,9 @@ def test_alert_create_approaching_mode_without_area_returns_422(client, alert_da
     )
     response = client.post("/api/v2/alerts/", payload, content_type="application/json")
     assert response.status_code == 422
-    assert "area_filter_mode" in response.json()["errors"]
+    data = response.json()
+    assert data["detail"] == "Validation failed"
+    assert "area_filter_mode" in data["errors"]
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1850,3 +1850,30 @@ def test_mark_all_as_seen_respects_species_filter(
     assert resp.status_code == 200
     assert captured["ids"] == [target_obs.pk]
     assert other_obs.pk not in captured["ids"]
+
+
+# ---------------------------------------------------------------------------
+# Shared error schemas (PR1)
+# ---------------------------------------------------------------------------
+
+
+def test_detail_error_out_schema_shape():
+    """DetailErrorOut wraps a single human-readable string."""
+    from dashboard.api_v2_schemas import DetailErrorOut
+
+    obj = DetailErrorOut(detail="Something went wrong")
+    assert obj.detail == "Something went wrong"
+
+
+def test_validation_error_out_schema_shape():
+    """ValidationErrorOut carries a top-level detail and a per-field errors map."""
+    from dashboard.api_v2_schemas import ValidationErrorOut
+
+    obj = ValidationErrorOut(
+        detail="Validation failed",
+        errors={"speciesIds": ["At least one species must be selected"]},
+    )
+    assert obj.detail == "Validation failed"
+    assert obj.errors == {
+        "speciesIds": ["At least one species must be selected"]
+    }

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1613,6 +1613,7 @@ def test_signup_duplicate_username(client, auth_data):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "username" in resp.json()["errors"]
 
 
@@ -1629,6 +1630,7 @@ def test_signup_password_mismatch(client):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "errors" in resp.json()
 
 
@@ -1663,6 +1665,7 @@ def test_password_change_wrong_old_password(client, auth_data):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "old_password" in resp.json()["errors"]
 
 
@@ -1692,6 +1695,7 @@ def test_password_change_mismatch(client, auth_data):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "new_password2" in resp.json()["errors"]
 
 
@@ -1787,6 +1791,7 @@ def test_profile_put_duplicate_email(client, auth_data):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "email" in resp.json()["errors"]
 
 
@@ -1806,6 +1811,7 @@ def test_profile_put_invalid_delay_unit(client, auth_data):
         content_type="application/json",
     )
     assert resp.status_code == 422
+    assert resp.json()["detail"] == "Validation failed"
     assert "delayUnit" in resp.json()["errors"]
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -980,6 +980,17 @@ def test_comments_empty_list_when_none(client, observation_detail_data):
     assert response.json()["comments"] == []
 
 
+def test_observation_add_comment_anonymous_returns_401(client, observation_detail_data):
+    """Anonymous users may not post comments. They get 401, not 403."""
+    obs = observation_detail_data["obs"]
+    resp = client.post(
+        f"/api/v2/observations/{obs.stable_id}/comments/",
+        data={"text": "Anonymous attempt"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 401
+
+
 # ---------------------------------------------------------------------------
 # ApiV2ObservationsMunicipalityVerifiedSortTests fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First PR of the API v2 hygiene cleanup. Resolves audit findings M1 (inconsistent error envelopes) and M2 (mixed auth patterns).

- Adds two shared error schemas in `dashboard/api_v2_schemas.py`:
  - `DetailErrorOut` (single message) - the Ninja default made explicit
  - `ValidationErrorOut` (top-level `detail` + per-field `errors` map)
- Migrates all 10 endpoints that used the five deprecated error schemas (`AreaCreateError`, `AreaDeleteError`, `AuthErrorOut`, `AlertValidationErrorOut`, `AuthValidationErrorOut`) to the new shared ones, then deletes the deprecated definitions.
- Switches the two endpoints that did manual `is_authenticated` checks (`observation_add_comment`, `observation_mark_unseen`) to `auth=django_auth` so unauthenticated callers consistently get 401 (not 403). 403 is preserved for genuine "authenticated but not allowed" cases (e.g. the no-matching-alert path in `observation_mark_unseen`).
- Includes a small mypy fix in `observation_add_comment`: removing the manual `is_authenticated` check stopped mypy from narrowing `request.user` from `User | AnonymousUser` to `User`; resolved with `cast(User, request.user)` matching the existing pattern in `area_create`.

The validation envelope gains a top-level `detail: "Validation failed"` alongside the existing `errors: {field: [msg]}` map. **The SPA reads `data.errors ?? {}` only** (verified across `SignUpPage`, `AlertFormPage`, `PasswordChangePage`, `UserProfilePage`), so the new field is additive and transparent to the frontend.

This is PR1 of ~7 themed PRs that bring v2 to a publishable hygiene baseline; see the design doc in the Obsidian project folder for the full plan.

## Test plan

- [x] Backend pytest (`dashboard/tests/views/test_api_v2.py`) - 124 passed
- [x] Full Django pytest (`dashboard/tests/` excluding playwright) - 391 passed
- [x] Playwright e2e (after fresh `vite-build`) - 82 passed
- [x] mypy clean (`Success: no issues found in 76 source files`)
- [x] TS types regenerated via `npm run generate-types`; diff reviewed

## Follow-up flagged

- `observation_mark_unseen` response declaration is still `response={200: dict, 403: dict}` (untyped). This is one of six untyped-dict endpoints scheduled for PR2 ("Untyped-dict elimination"), so it stays here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)