### PR TITLE
feat(api): SPA-only namespace at /api/v2/spa/ (PR3 of API hygiene)

### DIFF
--- a/assets/frontend/pages/AboutSitePage.vue
+++ b/assets/frontend/pages/AboutSitePage.vue
@@ -8,7 +8,7 @@ const html = ref<string | null>(null);
 const loading = ref(true);
 
 onMounted(async () => {
-    const resp = await fetch("/api/v2/page-fragments/about_this_site_page_content/");
+    const resp = await fetch("/api/v2/spa/page-fragments/about_this_site_page_content/");
     if (resp.ok) {
         const data = await resp.json();
         html.value = data.html;

--- a/assets/frontend/pages/AlertFormPage.vue
+++ b/assets/frontend/pages/AlertFormPage.vue
@@ -115,7 +115,7 @@ async function loadAlertData() {
 }
 
 async function suggestName() {
-    const res = await fetch("/api/v2/alerts/suggest-name/");
+    const res = await fetch("/api/v2/spa/alerts/suggest-name/");
     if (!res.ok) return;
     name.value = (await res.json()).name;
 }

--- a/assets/frontend/pages/IndexPage.vue
+++ b/assets/frontend/pages/IndexPage.vue
@@ -26,7 +26,7 @@ const unseenFallback = computed(() => isAuthenticated && !route.query.status);
 
 const welcomeHtml = ref("");
 onMounted(async () => {
-    const resp = await fetch("/api/v2/page-fragments/welcome_text/");
+    const resp = await fetch("/api/v2/spa/page-fragments/welcome_text/");
     if (resp.ok) {
         const data = await resp.json();
         welcomeHtml.value = data.html;

--- a/assets/frontend/pages/NewsPage.vue
+++ b/assets/frontend/pages/NewsPage.vue
@@ -10,12 +10,12 @@ const loading = ref(true);
 
 onMounted(async () => {
     // Fire and forget - mark news as visited without blocking the UI
-    fetch("/api/v2/news/mark-visited/", {
+    fetch("/api/v2/spa/news/mark-visited/", {
         method: "POST",
         headers: { "X-CSRFToken": getCsrf() },
     });
 
-    const resp = await fetch("/api/v2/page-fragments/news_page_content/");
+    const resp = await fetch("/api/v2/spa/page-fragments/news_page_content/");
     if (resp.ok) {
         const data = await resp.json();
         html.value = data.html;

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -271,29 +271,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/page-fragments/{identifier}/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Page Fragment
-         * @description Return the rendered HTML for a page fragment in the current request language.
-         *
-         *     Returns {"html": ""} if the fragment does not exist, so callers never need
-         *     to handle 404 - a missing fragment simply shows nothing.
-         */
-        get: operations["dashboard_api_v2_page_fragment"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v2/observations/{stable_id}/mark-unseen/": {
         parameters: {
             query?: never;
@@ -305,26 +282,6 @@ export interface paths {
         put?: never;
         /** Observation Mark Unseen */
         post: operations["dashboard_api_v2_observation_mark_unseen"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v2/alerts/suggest-name/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Alert Suggest Name
-         * @description Suggest the next available 'My alert #N' name for the current user.
-         */
-        get: operations["dashboard_api_v2_alert_suggest_name"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -403,26 +360,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/alerts/{alert_id}/as-filters/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Alert As Filters V2
-         * @description Return the alert's filters in DashboardFilters shape for pre-loading the index page.
-         */
-        get: operations["dashboard_api_v2_alert_as_filters_v2"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v2/auth/signin/": {
         parameters: {
             query?: never;
@@ -477,26 +414,6 @@ export interface paths {
          * @description Change password. Returns 204 on success, 422 with field errors on failure.
          */
         post: operations["dashboard_api_v2_auth_password_change"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v2/news/mark-visited/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * News Mark Visited
-         * @description Mark news as visited for the current user. No-op for anonymous users.
-         */
-        post: operations["dashboard_api_v2_news_mark_visited"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1407,30 +1324,6 @@ export interface operations {
             };
         };
     };
-    dashboard_api_v2_page_fragment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-    };
     dashboard_api_v2_observation_mark_unseen: {
         parameters: {
             query?: never;
@@ -1455,28 +1348,6 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-    };
-    dashboard_api_v2_alert_suggest_name: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -1638,30 +1509,6 @@ export interface operations {
             };
         };
     };
-    dashboard_api_v2_alert_as_filters_v2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                alert_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-    };
     dashboard_api_v2_auth_signin: {
         parameters: {
             query?: never;
@@ -1756,24 +1603,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ValidationErrorOut"];
                 };
-            };
-        };
-    };
-    dashboard_api_v2_news_mark_visited: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description No Content */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -94,6 +94,35 @@ api_v2 = NinjaAPI(
     },
 )
 
+# Internal SPA helper API - a second Ninja instance mounted at /api/v2/spa/.
+# These endpoints exist only to serve the single-page application; they are NOT
+# part of the public API contract and may change or disappear between releases.
+# Keeping them on a separate instance keeps the public /api/v2/ OpenAPI docs
+# limited to endpoints we are willing to commit to.
+api_v2_spa = NinjaAPI(
+    urls_namespace="api-v2-spa",
+    title="GBIF Alert SPA helper API",
+    version=human_readable_git_version_number(),
+    description=(
+        "Internal helper endpoints for the GBIF Alert single-page application. "
+        "These are not part of the public API contract and may change between "
+        "releases. For the public API see `/api/v2/docs`.\n\n"
+        "Source: https://github.com/riparias/gbif-alert"
+    ),
+    openapi_extra={
+        "info": {
+            "contact": {
+                "name": "GBIF Alert maintainers",
+                "url": "https://github.com/riparias/gbif-alert",
+            },
+            "license": {
+                "name": "MIT",
+                "url": "https://opensource.org/licenses/MIT",
+            },
+        }
+    },
+)
+
 
 @api_v2.get("/species/", response=list[SpeciesOut])
 def species_list(request: HttpRequest):

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -607,7 +607,7 @@ def observation_add_comment(request: HttpRequest, stable_id: str, payload: Comme
     }
 
 
-@api_v2.get("/page-fragments/{identifier}/", response=dict)
+@api_v2_spa.get("/page-fragments/{identifier}/", response=dict)
 def page_fragment(request: HttpRequest, identifier: str):
     """Return the rendered HTML for a page fragment in the current request language.
 
@@ -719,7 +719,7 @@ def _save_alert(alert: Alert, payload: AlertIn) -> dict[str, list[str]]:
 # routes so they are not captured as alert IDs.
 
 
-@api_v2.get("/alerts/suggest-name/", response=dict, auth=django_auth)
+@api_v2_spa.get("/alerts/suggest-name/", response=dict, auth=django_auth)
 def alert_suggest_name(request: HttpRequest):
     """Suggest the next available 'My alert #N' name for the current user."""
     user = cast(User, request.user)
@@ -805,13 +805,6 @@ def alert_delete(request: HttpRequest, alert_id: int):
     return 204, None
 
 
-@api_v2.get("/alerts/{alert_id}/as-filters/", response=dict, auth=django_auth)
-def alert_as_filters_v2(request: HttpRequest, alert_id: int):
-    """Return the alert's filters in DashboardFilters shape for pre-loading the index page."""
-    alert = get_object_or_404(Alert, id=alert_id, user=request.user)
-    return alert.as_dashboard_filters
-
-
 # ---- Auth endpoints ----
 
 
@@ -881,7 +874,7 @@ def auth_password_change(request: HttpRequest, payload: PasswordChangeIn):
     return 204, None
 
 
-@api_v2.post(
+@api_v2_spa.post(
     "/news/mark-visited/",
     response={204: None},
     auth=None,

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -1201,26 +1201,6 @@ class Alert(models.Model):
         return ", ".join(self.species.order_by("name").values_list("name", flat=True))
 
     @property
-    def as_dashboard_filters(self) -> dict[str, Any]:
-        """The alert represented as a dict
-
-        Once converted to JSON, this dict is suitable for Observation filtering in the frontend
-        (see DashboardFilters TypeScript interface).
-        """
-        return {
-            "speciesIds": [s.pk for s in self.species.all()],
-            "datasetsIds": [d.pk for d in self.datasets.all()],
-            "basisOfRecordIds": [b.pk for b in self.basis_of_record_filters.all()],
-            "areaIds": [a.pk for a in self.areas.all()],
-            "startDate": None,
-            "endDate": None,
-            "status": "unseen",
-            "verifiedFilter": self.verified_filter,
-            "areaFilterMode": self.area_filter_mode,
-            "approachingDistanceKm": self.approaching_distance_km,
-        }
-
-    @property
     def as_dict(self) -> dict[str, Any]:
         return {
             "id": self.pk,

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -18,6 +18,7 @@ from dashboard.models import (
     ObservationUnseen,
     Species,
 )
+from page_fragments.models import PageFragment
 
 pytestmark = pytest.mark.django_db
 
@@ -1268,29 +1269,13 @@ def test_alert_delete_wrong_user_returns_404(client, alert_data):
     assert Alert.objects.filter(pk=alert.pk).exists()
 
 
-# --- GET /api/v2/alerts/{alert_id}/as-filters/ ---
-
-
-def test_alert_as_filters_returns_dashboard_filter_shape(client, alert_data):
-    alert = alert_data["alert"]
-    sp1 = alert_data["sp1"]
-    client.login(username="alertuser", password="12345")
-    response = client.get(f"/api/v2/alerts/{alert.pk}/as-filters/")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["speciesIds"] == [sp1.pk]
-    assert data["status"] == "unseen"
-    assert "verifiedFilter" in data
-    assert "areaFilterMode" in data
-
-
 # --- GET /api/v2/alerts/suggest-name/ ---
 
 
 def test_suggest_name_returns_first_available(client, alert_data):
     # "My alert #1" is taken; next should be "My alert #2"
     client.login(username="alertuser", password="12345")
-    response = client.get("/api/v2/alerts/suggest-name/")
+    response = client.get("/api/v2/spa/alerts/suggest-name/")
     assert response.status_code == 200
     assert response.json()["name"] == "My alert #2"
 
@@ -1705,12 +1690,12 @@ def test_password_change_mismatch(client, auth_data):
 def test_news_mark_visited_authenticated(client, auth_data):
     user = auth_data["user"]
     client.force_login(user)
-    resp = client.post("/api/v2/news/mark-visited/", content_type="application/json")
+    resp = client.post("/api/v2/spa/news/mark-visited/", content_type="application/json")
     assert resp.status_code == 204
 
 
 def test_news_mark_visited_anonymous(client):
-    resp = client.post("/api/v2/news/mark-visited/", content_type="application/json")
+    resp = client.post("/api/v2/spa/news/mark-visited/", content_type="application/json")
     assert resp.status_code == 204
 
 
@@ -1944,3 +1929,56 @@ def test_spa_openapi_schema_is_served_and_marked_internal(client):
     assert resp.status_code == 200
     schema = resp.json()
     assert "not part of the public API contract" in schema["info"]["description"]
+
+
+def test_page_fragment_returns_html_under_spa_namespace(client):
+    """page-fragments is served under /api/v2/spa/ and returns rendered HTML."""
+    # Set all three language fields so the result is locale-independent
+    # (get_content_in falls back to other languages when a field is empty).
+    PageFragment.objects.create(
+        identifier="welcome_text",
+        content_en="# Hello",
+        content_nl="# Hello",
+        content_fr="# Hello",
+    )
+    resp = client.get("/api/v2/spa/page-fragments/welcome_text/")
+    assert resp.status_code == 200
+    assert "Hello" in resp.json()["html"]
+
+
+def test_page_fragment_missing_returns_empty_html_under_spa_namespace(client):
+    """A missing fragment yields {"html": ""} rather than a 404."""
+    resp = client.get("/api/v2/spa/page-fragments/does_not_exist/")
+    assert resp.status_code == 200
+    assert resp.json()["html"] == ""
+
+
+def test_relocated_endpoints_gone_from_public_namespace(client, alert_data):
+    """The four in-scope endpoints (3 relocated, 1 deleted) no longer answer under /api/v2/.
+
+    suggest-name returns 422 (not 404) because Ninja matches the path against
+    the existing /alerts/{alert_id}/ route with "suggest-name" as a non-integer
+    param - this is expected Ninja validation behaviour, not a successful response.
+    """
+    alert = alert_data["alert"]
+    client.login(username="alertuser", password="12345")
+
+    # suggest-name is gone; Ninja returns 422 (param type mismatch on {alert_id})
+    # rather than 404 because /alerts/{alert_id}/ still exists. Assert a 4xx
+    # client error (not == 422) so the test survives a future route change, while
+    # still failing on a 2xx (endpoint accidentally re-added) or a 5xx server error.
+    suggest_status = client.get("/api/v2/alerts/suggest-name/").status_code
+    assert 400 <= suggest_status < 500, (
+        f"suggest-name should return a client error on the public namespace "
+        f"(got {suggest_status})"
+    )
+
+    # as-filters was deleted (dead code), so it is gone from the public surface too.
+    assert client.get(f"/api/v2/alerts/{alert.pk}/as-filters/").status_code == 404
+    assert (
+        client.post(
+            "/api/v2/news/mark-visited/", content_type="application/json"
+        ).status_code
+        == 404
+    )
+    assert client.get("/api/v2/page-fragments/welcome_text/").status_code == 404

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1269,7 +1269,7 @@ def test_alert_delete_wrong_user_returns_404(client, alert_data):
     assert Alert.objects.filter(pk=alert.pk).exists()
 
 
-# --- GET /api/v2/alerts/suggest-name/ ---
+# --- GET /api/v2/spa/alerts/suggest-name/ ---
 
 
 def test_suggest_name_returns_first_available(client, alert_data):

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1917,3 +1917,22 @@ def test_validation_error_out_schema_shape():
     assert obj.errors == {
         "speciesIds": ["At least one species must be selected"]
     }
+
+
+# ---------------------------------------------------------------------------
+# SPA-only namespace (PR3)
+# ---------------------------------------------------------------------------
+
+
+def test_api_v2_spa_instance_exists_and_is_marked_internal():
+    """The SPA helper API is a separate NinjaAPI marked as non-public."""
+    from ninja import NinjaAPI
+
+    from dashboard.api_v2 import api_v2, api_v2_spa
+
+    assert isinstance(api_v2_spa, NinjaAPI)
+    # Distinct namespace so django-ninja does not raise at startup.
+    assert api_v2_spa.urls_namespace == "api-v2-spa"
+    assert api_v2.urls_namespace != api_v2_spa.urls_namespace
+    # Description warns consumers it is not part of the public contract.
+    assert "not part of the public API contract" in api_v2_spa.description

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1936,3 +1936,11 @@ def test_api_v2_spa_instance_exists_and_is_marked_internal():
     assert api_v2.urls_namespace != api_v2_spa.urls_namespace
     # Description warns consumers it is not part of the public contract.
     assert "not part of the public API contract" in api_v2_spa.description
+
+
+def test_spa_openapi_schema_is_served_and_marked_internal(client):
+    """The SPA helper API serves its own OpenAPI schema at /api/v2/spa/."""
+    resp = client.get("/api/v2/spa/openapi.json")
+    assert resp.status_code == 200
+    schema = resp.json()
+    assert "not part of the public API contract" in schema["info"]["description"]

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1982,3 +1982,40 @@ def test_relocated_endpoints_gone_from_public_namespace(client, alert_data):
         == 404
     )
     assert client.get("/api/v2/page-fragments/welcome_text/").status_code == 404
+
+
+def test_public_schema_excludes_relocated_endpoints(client):
+    """The public /api/v2/ OpenAPI paths no longer mention the in-scope endpoints.
+
+    django-ninja renders the full mount prefix into the path keys, so they look
+    like /api/v2/alerts/. The anchor assertion below guards against a future
+    ninja change to that format silently making the exclusion checks vacuous.
+    """
+    resp = client.get("/api/v2/openapi.json")
+    assert resp.status_code == 200
+    public_paths = set(resp.json()["paths"].keys())
+
+    # Anchor: a known public endpoint must be present in the expected key format.
+    assert "/api/v2/alerts/" in public_paths
+
+    assert "/api/v2/alerts/suggest-name/" not in public_paths
+    assert "/api/v2/alerts/{alert_id}/as-filters/" not in public_paths  # deleted entirely
+    assert "/api/v2/news/mark-visited/" not in public_paths
+    assert "/api/v2/page-fragments/{identifier}/" not in public_paths
+
+
+def test_spa_schema_includes_relocated_endpoints(client):
+    """The SPA schema is where the three relocated endpoints now live.
+
+    django-ninja renders the full mount prefix into the SPA schema's path keys,
+    so each path starts with /api/v2/spa/.
+    """
+    resp = client.get("/api/v2/spa/openapi.json")
+    assert resp.status_code == 200
+    spa_paths = set(resp.json()["paths"].keys())
+
+    assert "/api/v2/spa/alerts/suggest-name/" in spa_paths
+    assert "/api/v2/spa/news/mark-visited/" in spa_paths
+    assert "/api/v2/spa/page-fragments/{identifier}/" in spa_paths
+    # as-filters was deleted, not relocated - it must NOT reappear here.
+    assert "/api/v2/spa/alerts/{alert_id}/as-filters/" not in spa_paths

--- a/djangoproject/urls.py
+++ b/djangoproject/urls.py
@@ -17,11 +17,12 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import path, include, re_path, reverse_lazy
 
-from dashboard.api_v2 import api_v2
+from dashboard.api_v2 import api_v2, api_v2_spa
 from dashboard.views.healthz import healthz
 from dashboard.views.pages import spa_shell
 
 urlpatterns = [
+    path("api/v2/spa/", api_v2_spa.urls),
     path("api/v2/", api_v2.urls),
     path("", include("dashboard.urls")),
     # User accounts


### PR DESCRIPTION
## Summary

Third PR of the API v2 hygiene cleanup. Resolves audit finding M9 (and
incidentally N12): SPA-only helper endpoints are moved off the public
`/api/v2/` surface so the public docs only show endpoints we are willing to
commit to.

- Adds a second `NinjaAPI` instance, `api_v2_spa`, mounted at `/api/v2/spa/`
  with a description that explicitly marks it as non-public.
- Relocates three endpoints (decorator swap only; bodies unchanged):
  - `GET /alerts/suggest-name/`
  - `POST /news/mark-visited/`
  - `GET /page-fragments/{identifier}/`
- **Deletes** `GET /alerts/{alert_id}/as-filters/` and its only consumer, the
  `Alert.as_dashboard_filters` model property: the design doc earmarked the
  endpoint for relocation, but it has zero callers (no SPA, template, or Python
  use; the SPA's `AlertDetailPage` reconstructs filters manually). Relocating
  dead code would just preserve cruft, so both are removed.
- Repoints the five SPA fetch call-sites (across `AlertFormPage`, `NewsPage`,
  `AboutSitePage`, `IndexPage`) to the new paths.
- Adds the first `page-fragments` tests, plus regression guards that all four
  in-scope endpoints are absent from `/api/v2/openapi.json` and that the three
  relocated ones are present in `/api/v2/spa/openapi.json`.

Type generation for the SPA-only endpoints is intentionally deferred to PR2
(typed-dict elimination); the public `api.ts` simply drops the four paths.

See the design doc in the project's planning folder for the full 7-PR plan.

## Test plan

- [x] Backend pytest passes (397; incl. new SPA-namespace and page-fragment tests)
- [x] mypy clean
- [x] Playwright full suite passes (index, about, news, alert-form flows)
- [x] TS types regenerated; diff reviewed (pure removal of the 4 paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)