### PR TITLE
feat(api): type the dict-returning v2 endpoints (PR2 of API hygiene)

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -514,6 +514,44 @@ export interface components {
             /** Detail */
             detail: string;
         };
+        /**
+         * GeoJSONFeatureCollectionOut
+         * @description A GeoJSON FeatureCollection (EPSG:4326) from Django's geojson serializer.
+         *
+         *     Declares the exact members Django emits (`type`, `crs`, `features`) so that
+         *     typing the response does not drop the `crs` member from the wire format.
+         */
+        GeoJSONFeatureCollectionOut: {
+            /** Type */
+            type: string;
+            /** Crs */
+            crs: {
+                [key: string]: unknown;
+            };
+            /** Features */
+            features: components["schemas"]["GeoJSONFeatureOut"][];
+        };
+        /**
+         * GeoJSONFeatureOut
+         * @description A single GeoJSON Feature as produced by Django's geojson serializer.
+         *
+         *     `geometry` and `properties` are passed through untyped - the schema
+         *     documents the Feature envelope without constraining the geometry internals.
+         */
+        GeoJSONFeatureOut: {
+            /** Type */
+            type: string;
+            /** Id */
+            id: number;
+            /** Properties */
+            properties: {
+                [key: string]: unknown;
+            };
+            /** Geometry */
+            geometry: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** AreaFromDrawingIn */
         AreaFromDrawingIn: {
             /** Name */
@@ -646,6 +684,14 @@ export interface components {
             /** Count */
             count: number;
         };
+        /**
+         * QueuedOut
+         * @description Acknowledgement that a bulk operation was queued for async processing.
+         */
+        QueuedOut: {
+            /** Queued */
+            queued: boolean;
+        };
         /** CommentOut */
         CommentOut: {
             /** Id */
@@ -720,6 +766,14 @@ export interface components {
         CommentIn: {
             /** Text */
             text: string;
+        };
+        /**
+         * OkOut
+         * @description Simple boolean acknowledgement response.
+         */
+        OkOut: {
+            /** Ok */
+            ok: boolean;
         };
         /** AlertNotificationFrequencyOut */
         AlertNotificationFrequencyOut: {
@@ -1030,9 +1084,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["GeoJSONFeatureCollectionOut"];
                 };
             };
         };
@@ -1269,9 +1321,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["QueuedOut"];
                 };
             };
         };
@@ -1341,9 +1391,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["OkOut"];
                 };
             };
             /** @description Forbidden */
@@ -1352,9 +1400,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -488,9 +488,7 @@ def observations_histogram(request: HttpRequest, filters: Query[FiltersQuery]):
     response={200: QueuedOut},
     auth=django_auth,
 )
-def observations_mark_all_as_seen(
-    request: HttpRequest, filters: Query[FiltersQuery]
-):
+def observations_mark_all_as_seen(request: HttpRequest, filters: Query[FiltersQuery]):
     """Bulk-mark all observations matching the current filters as seen by
     the requesting user. Runs asynchronously via django-rq."""
     user = cast(User, request.user)
@@ -724,7 +722,9 @@ def _save_alert(alert: Alert, payload: AlertIn) -> dict[str, list[str]]:
 # routes so they are not captured as alert IDs.
 
 
-@api_v2_spa.get("/alerts/suggest-name/", response=AlertNameSuggestionOut, auth=django_auth)
+@api_v2_spa.get(
+    "/alerts/suggest-name/", response=AlertNameSuggestionOut, auth=django_auth
+)
 def alert_suggest_name(request: HttpRequest):
     """Suggest the next available 'My alert #N' name for the current user."""
     user = cast(User, request.user)
@@ -927,7 +927,10 @@ def profile_put(request: HttpRequest, payload: ProfileIn):
         }
     valid_units = ("days", "weeks", "months", "years")
     if payload.delayUnit not in valid_units:
-        return 422, {"detail": "Validation failed", "errors": {"delayUnit": ["Invalid unit."]}}
+        return 422, {
+            "detail": "Validation failed",
+            "errors": {"delayUnit": ["Invalid unit."]},
+        }
     user.first_name = payload.firstName
     user.last_name = payload.lastName
     user.email = payload.email

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -612,7 +612,7 @@ def observation_add_comment(request: HttpRequest, stable_id: str, payload: Comme
     }
 
 
-@api_v2_spa.get("/page-fragments/{identifier}/", response=dict)
+@api_v2_spa.get("/page-fragments/{identifier}/", response=PageFragmentOut)
 def page_fragment(request: HttpRequest, identifier: str):
     """Return the rendered HTML for a page fragment in the current request language.
 
@@ -724,7 +724,7 @@ def _save_alert(alert: Alert, payload: AlertIn) -> dict[str, list[str]]:
 # routes so they are not captured as alert IDs.
 
 
-@api_v2_spa.get("/alerts/suggest-name/", response=dict, auth=django_auth)
+@api_v2_spa.get("/alerts/suggest-name/", response=AlertNameSuggestionOut, auth=django_auth)
 def alert_suggest_name(request: HttpRequest):
     """Suggest the next available 'My alert #N' name for the current user."""
     user = cast(User, request.user)

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -21,6 +21,7 @@ from pydantic import Field
 
 from dashboard.api_v2_schemas import (
     AlertIn,
+    AlertNameSuggestionOut,
     AlertNotificationFrequencyOut,
     AlertOut,
     AreaFromDrawingIn,
@@ -33,12 +34,16 @@ from dashboard.api_v2_schemas import (
     DatasetOut,
     DetailErrorOut,
     FiltersQuery,
+    GeoJSONFeatureCollectionOut,
     HistogramEntryOut,
     ObservationDetailOut,
     ObservationsPageOut,
+    OkOut,
+    PageFragmentOut,
     PasswordChangeIn,
     ProfileIn,
     ProfileOut,
+    QueuedOut,
     SignInIn,
     SignInOut,
     SignUpIn,
@@ -159,7 +164,7 @@ def areas_list(request: HttpRequest):
     ]
 
 
-@api_v2.get("/areas/{area_id}/geojson/", response=dict)
+@api_v2.get("/areas/{area_id}/geojson/", response=GeoJSONFeatureCollectionOut)
 def area_geojson(request: HttpRequest, area_id: int):
     """Return GeoJSON (FeatureCollection, EPSG:4326) for a single area.
 
@@ -480,7 +485,7 @@ def observations_histogram(request: HttpRequest, filters: Query[FiltersQuery]):
 
 @api_v2.post(
     "/observations/mark-as-seen/",
-    response={200: dict},
+    response={200: QueuedOut},
     auth=django_auth,
 )
 def observations_mark_all_as_seen(
@@ -624,7 +629,7 @@ def page_fragment(request: HttpRequest, identifier: str):
 
 @api_v2.post(
     "/observations/{stable_id}/mark-unseen/",
-    response={200: dict, 403: dict},
+    response={200: OkOut, 403: DetailErrorOut},
     auth=django_auth,
 )
 def observation_mark_unseen(request: HttpRequest, stable_id: str):

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -247,3 +247,52 @@ class ValidationErrorOut(Schema):
 
     detail: str
     errors: dict[str, list[str]]
+
+
+class QueuedOut(Schema):
+    """Acknowledgement that a bulk operation was queued for async processing."""
+
+    queued: bool
+
+
+class OkOut(Schema):
+    """Simple boolean acknowledgement response."""
+
+    ok: bool
+
+
+class PageFragmentOut(Schema):
+    """Rendered HTML for a page fragment (internal SPA helper endpoint)."""
+
+    html: str
+
+
+class AlertNameSuggestionOut(Schema):
+    """A suggested, not-yet-used alert name (internal SPA helper endpoint)."""
+
+    name: str
+
+
+class GeoJSONFeatureOut(Schema):
+    """A single GeoJSON Feature as produced by Django's geojson serializer.
+
+    `geometry` and `properties` are passed through untyped - the schema
+    documents the Feature envelope without constraining the geometry internals.
+    """
+
+    type: str
+    id: int
+    properties: dict
+    geometry: dict | None
+
+
+class GeoJSONFeatureCollectionOut(Schema):
+    """A GeoJSON FeatureCollection (EPSG:4326) from Django's geojson serializer.
+
+    Declares the exact members Django emits (`type`, `crs`, `features`) so that
+    typing the response does not drop the `crs` member from the wire format.
+    """
+
+    type: str
+    crs: dict
+    features: list[GeoJSONFeatureOut]

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1690,12 +1690,16 @@ def test_password_change_mismatch(client, auth_data):
 def test_news_mark_visited_authenticated(client, auth_data):
     user = auth_data["user"]
     client.force_login(user)
-    resp = client.post("/api/v2/spa/news/mark-visited/", content_type="application/json")
+    resp = client.post(
+        "/api/v2/spa/news/mark-visited/", content_type="application/json"
+    )
     assert resp.status_code == 204
 
 
 def test_news_mark_visited_anonymous(client):
-    resp = client.post("/api/v2/spa/news/mark-visited/", content_type="application/json")
+    resp = client.post(
+        "/api/v2/spa/news/mark-visited/", content_type="application/json"
+    )
     assert resp.status_code == 204
 
 
@@ -1868,9 +1872,7 @@ def test_mark_all_as_seen_respects_species_filter(
     other_obs = observations_data["obs_other_species"]
 
     client.force_login(user)
-    resp = client.post(
-        f"/api/v2/observations/mark-as-seen/?speciesIds={species.pk}"
-    )
+    resp = client.post(f"/api/v2/observations/mark-as-seen/?speciesIds={species.pk}")
 
     assert resp.status_code == 200
     assert captured["ids"] == [target_obs.pk]
@@ -1899,9 +1901,7 @@ def test_validation_error_out_schema_shape():
         errors={"speciesIds": ["At least one species must be selected"]},
     )
     assert obj.detail == "Validation failed"
-    assert obj.errors == {
-        "speciesIds": ["At least one species must be selected"]
-    }
+    assert obj.errors == {"speciesIds": ["At least one species must be selected"]}
 
 
 # ---------------------------------------------------------------------------
@@ -1999,7 +1999,9 @@ def test_public_schema_excludes_relocated_endpoints(client):
     assert "/api/v2/alerts/" in public_paths
 
     assert "/api/v2/alerts/suggest-name/" not in public_paths
-    assert "/api/v2/alerts/{alert_id}/as-filters/" not in public_paths  # deleted entirely
+    assert (
+        "/api/v2/alerts/{alert_id}/as-filters/" not in public_paths
+    )  # deleted entirely
     assert "/api/v2/news/mark-visited/" not in public_paths
     assert "/api/v2/page-fragments/{identifier}/" not in public_paths
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2067,3 +2067,24 @@ def test_geojson_feature_collection_schema_shape():
     assert fc.features[0].geometry["type"] == "Polygon"
     # crs must survive a round-trip dump (it is easy to accidentally drop).
     assert "crs" in fc.model_dump()
+
+
+def test_area_geojson_response_is_unchanged_after_typing(client, area_endpoints_data):
+    """Typing the response with a Schema must not drop keys (crs, feature id).
+
+    The endpoint output must remain byte-identical to Django's raw geojson
+    serializer output.
+    """
+    from django.core.serializers import serialize
+
+    area = area_endpoints_data["area"]
+    client.login(username="owner", password="pass")
+
+    resp = client.get(f"/api/v2/areas/{area.pk}/geojson/")
+    assert resp.status_code == 200
+
+    expected = json.loads(serialize("geojson", [area], srid=4326))
+    assert resp.json() == expected
+    # Guard the specific members a naive schema would have dropped.
+    assert "crs" in resp.json()
+    assert "id" in resp.json()["features"][0]

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2019,3 +2019,51 @@ def test_spa_schema_includes_relocated_endpoints(client):
     assert "/api/v2/spa/page-fragments/{identifier}/" in spa_paths
     # as-filters was deleted, not relocated - it must NOT reappear here.
     assert "/api/v2/spa/alerts/{alert_id}/as-filters/" not in spa_paths
+
+
+# ---------------------------------------------------------------------------
+# Typed response schemas (PR2)
+# ---------------------------------------------------------------------------
+
+
+def test_simple_dict_out_schemas_shapes():
+    """The small status/value schemas carry exactly one typed field each."""
+    from dashboard.api_v2_schemas import (
+        AlertNameSuggestionOut,
+        OkOut,
+        PageFragmentOut,
+        QueuedOut,
+    )
+
+    assert QueuedOut(queued=True).queued is True
+    assert OkOut(ok=True).ok is True
+    assert PageFragmentOut(html="<p>hi</p>").html == "<p>hi</p>"
+    assert AlertNameSuggestionOut(name="My alert #1").name == "My alert #1"
+
+
+def test_geojson_feature_collection_schema_shape():
+    """The FeatureCollection schema nests features and preserves the crs member."""
+    from dashboard.api_v2_schemas import (
+        GeoJSONFeatureCollectionOut,
+        GeoJSONFeatureOut,
+    )
+
+    fc = GeoJSONFeatureCollectionOut(
+        type="FeatureCollection",
+        crs={"type": "name", "properties": {"name": "EPSG:4326"}},
+        features=[
+            GeoJSONFeatureOut(
+                type="Feature",
+                id=1,
+                properties={"pk": "1"},
+                geometry={
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]],
+                },
+            )
+        ],
+    )
+    assert fc.type == "FeatureCollection"
+    assert fc.features[0].geometry["type"] == "Polygon"
+    # crs must survive a round-trip dump (it is easy to accidentally drop).
+    assert "crs" in fc.model_dump()


### PR DESCRIPTION
## Summary

API v2 hygiene cleanup - "PR2: untyped-dict elimination" (PR1 #319 and PR3 #320 already merged). Resolves audit finding **M3**: no endpoint returns a bare `dict` anymore - every response has a typed schema, so the OpenAPI docs and generated TS types describe real shapes instead of `{[key: string]: unknown}`.

- Adds typed schemas in `dashboard/api_v2_schemas.py`: `QueuedOut`, `OkOut`, `PageFragmentOut`, `AlertNameSuggestionOut`, and `GeoJSONFeatureOut` / `GeoJSONFeatureCollectionOut`.
- Types five endpoints in `dashboard/api_v2.py` (declaration-only; bodies unchanged):
  - public: `area_geojson` -> `GeoJSONFeatureCollectionOut`, `mark-as-seen` -> `{200: QueuedOut}`, `mark-unseen` -> `{200: OkOut, 403: DetailErrorOut}`.
  - spa: `page-fragments` -> `PageFragmentOut`, `alerts/suggest-name` -> `AlertNameSuggestionOut`.
- The GeoJSON schema declares Django's exact serializer members (`type`, `crs`, `features[type,id,properties,geometry]`); a pinning test in `dashboard/tests/views/test_api_v2.py` asserts the response stays byte-identical to the raw serializer output, so `crs` / feature-`id` are never dropped.
- Regenerates `assets/frontend/types/api.ts`: the three public endpoints' responses tighten from `unknown` to concrete types. The spa endpoints are typed on the Python side (accurate `/api/v2/spa/docs`) but stay out of the public `api.ts`; generating TS types for the spa surface is deferred (the SPA calls them via raw `fetch()`).

No functional SPA changes - all five endpoints are consumed via raw `fetch()`.

## Out of scope (deferred)
- `count` on the bulk mark-as-seen response (audit item N2 -> PR7); this PR types the current `{queued}` shape.
- `mark-unseen` 404 left undeclared in the response map (unchanged from before; ninja still propagates the `HttpError`).

## Test plan

- [x] Backend pytest passes (400; incl. new schema-shape + exact-output GeoJSON tests)
- [x] mypy clean
- [x] Playwright full suite passes (82; drawer, page fragments, alert-form flows)
- [x] black --check clean
- [x] TS types regenerated; diff reviewed (loose dict -> concrete types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)