### PR TITLE
feat(api): sort/validation/side-effect hygiene (PR5 of API hygiene)

### DIFF
--- a/assets/frontend/components/ObservationDetailPanel.vue
+++ b/assets/frontend/components/ObservationDetailPanel.vue
@@ -44,6 +44,15 @@ async function load() {
             return;
         }
         obs.value = await resp.json();
+        if (isAuthenticated) {
+            // The detail GET no longer marks the observation as seen (the API is
+            // side-effect free); do it explicitly so the table/sidebar reflect it
+            // when the drawer closes. Best-effort: seen state isn't load-critical.
+            await fetch(`/api/v2/observations/${props.stableId}/mark-as-seen/`, {
+                method: "POST",
+                headers: { "X-CSRFToken": getCsrf() },
+            }).catch(() => { /* non-fatal */ });
+        }
     } finally {
         loading.value = false;
     }

--- a/assets/frontend/components/ObservationsView.vue
+++ b/assets/frontend/components/ObservationsView.vue
@@ -53,9 +53,9 @@ function closeDrawer() {
     const q = { ...route.query };
     delete q.obs;
     router.replace({ query: q });
-    // Opening the drawer auto-marks the observation as seen server-side, and
-    // the drawer can also mark it as unseen, so any close potentially changed
-    // status. Notify watchers (table, sidebar counts, histogram, map, alert).
+    // The drawer marks the observation as seen on open (via an explicit POST),
+    // and can also mark it as unseen, so any close potentially changed status.
+    // Notify watchers (table, sidebar counts, histogram, map, alert).
     resultsStore.bumpStatusEpoch();
 }
 

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -1391,6 +1391,15 @@ export interface operations {
                     "application/json": components["schemas"]["CommentOut"];
                 };
             };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_observation_mark_unseen: {

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -272,6 +272,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/observations/{stable_id}/mark-as-seen/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Observation Mark As Seen
+         * @description Mark a single observation as seen by the requesting user.
+         *
+         *     Replaces the implicit side effect that the detail GET used to perform, so
+         *     that GET stays safe/idempotent (audit M11).
+         */
+        post: operations["dashboard_api_v2_observation_mark_as_seen"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/observations/{stable_id}/mark-unseen/": {
         parameters: {
             query?: never;
@@ -1398,6 +1421,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+        };
+    };
+    dashboard_api_v2_observation_mark_as_seen: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                stable_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OkOut"];
                 };
             };
         };

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -186,9 +186,10 @@ export interface paths {
          * List observations
          * @description Return a paginated, filtered, and sorted page of observations.
          *
-         *     Pagination is controlled by `page` (1-based) and `pageSize` (capped at 100).
+         *     Pagination is controlled by `page` (1-based) and `pageSize` (must be 1-100).
          *     Sorting is controlled by `orderBy` and `orderDir`. A secondary sort on `-pk`
          *     is always appended to guarantee stable pagination when the primary field has ties.
+         *     Invalid `orderBy`, `orderDir`, `page`, or `pageSize` values return 400.
          */
         get: operations["dashboard_api_v2_observations_list"];
         put?: never;
@@ -1267,6 +1268,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ObservationsPageOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -334,8 +334,16 @@ _LOCALISED_SORT_FIELDS = {"vernacularName"}
 # column. Mirrors the pattern in dashboard/views/maps.py.
 _VERNACULAR_LANG_CODES = {code[:2] for code, _name in settings.LANGUAGES}
 
+# Every orderBy value the list endpoint accepts. Unknown values are rejected
+# with 400 rather than silently coerced to date (audit M8).
+_ACCEPTED_ORDER_BY = set(_SIMPLE_SORT_FIELD_MAP) | _LOCALISED_SORT_FIELDS
 
-@api_v2.get("/observations/", response=ObservationsPageOut, summary="List observations")
+
+@api_v2.get(
+    "/observations/",
+    response={200: ObservationsPageOut, 400: DetailErrorOut},
+    summary="List observations",
+)
 def observations_list(
     request: HttpRequest,
     filters: Query[FiltersQuery],
@@ -344,24 +352,34 @@ def observations_list(
     orderBy: Annotated[
         str,
         Field(
-            description="Field to sort by. Accepted: date, scientificName, vernacularName, datasetName, municipality, verified. Unknown values fall back to date."
+            description="Field to sort by. Accepted: date, scientificName, vernacularName, datasetName, municipality, verified. An unknown value returns 400."
         ),
     ] = "date",
     orderDir: Annotated[
         str,
         Field(
-            description="Sort direction: asc or desc. Any value other than asc is treated as desc."
+            description="Sort direction: asc or desc. Any other value returns 400."
         ),
     ] = "desc",
 ):
     """Return a paginated, filtered, and sorted page of observations.
 
-    Pagination is controlled by `page` (1-based) and `pageSize` (capped at 100).
+    Pagination is controlled by `page` (1-based) and `pageSize` (must be 1-100).
     Sorting is controlled by `orderBy` and `orderDir`. A secondary sort on `-pk`
     is always appended to guarantee stable pagination when the primary field has ties.
+    Invalid `orderBy`, `orderDir`, `page`, or `pageSize` values return 400.
     """
-    pageSize = min(max(pageSize, 1), 100)
-    page = max(page, 1)
+    if orderBy not in _ACCEPTED_ORDER_BY:
+        accepted = ", ".join(sorted(_ACCEPTED_ORDER_BY))
+        return 400, {
+            "detail": f"Invalid orderBy '{orderBy}'. Accepted values: {accepted}."
+        }
+    if orderDir not in ("asc", "desc"):
+        return 400, {"detail": "Invalid orderDir. Accepted values: asc, desc."}
+    if not 1 <= pageSize <= 100:
+        return 400, {"detail": "Invalid pageSize. Must be between 1 and 100."}
+    if page < 1:
+        return 400, {"detail": "Invalid page. Must be 1 or greater."}
 
     user = request.user if request.user.is_authenticated else None
 
@@ -443,7 +461,7 @@ def observations_list(
         for obs in obs_page
     ]
 
-    return {
+    return 200, {
         "count": total,
         "speciesCount": aggregates["species_count"],
         "datasetsCount": aggregates["datasets_count"],

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -599,7 +599,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
 
 @api_v2.post(
     "/observations/{stable_id}/comments/",
-    response=CommentOut,
+    response={200: CommentOut, 422: DetailErrorOut},
     auth=django_auth,
 )
 def observation_add_comment(request: HttpRequest, stable_id: str, payload: CommentIn):
@@ -611,7 +611,8 @@ def observation_add_comment(request: HttpRequest, stable_id: str, payload: Comme
 
     text = payload.text.strip()
     if not text:
-        raise HttpError(400, "Comment text cannot be empty")
+        # Well-formed body but semantically invalid -> 422 (audit N3).
+        return 422, {"detail": "Comment text cannot be empty"}
 
     comment = ObservationComment.objects.create(
         observation=obs,
@@ -619,7 +620,7 @@ def observation_add_comment(request: HttpRequest, stable_id: str, payload: Comme
         text=text,
     )
 
-    return {
+    return 200, {
         "id": comment.pk,
         "authorUsername": user.username,
         "createdAt": comment.created_at,

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -539,14 +539,14 @@ def observation_detail(request: HttpRequest, stable_id: str):
 
     user = request.user if request.user.is_authenticated else None
 
-    obs.mark_as_seen_by(request.user)
-
     seen_by_current_user: bool | None = None
     can_be_marked_unseen = False
     if user is not None:
         seen_by_current_user = obs.already_seen_by(user)
-        if seen_by_current_user:
-            can_be_marked_unseen = user.obs_match_alerts(obs)
+        # canBeMarkedUnseen is a capability flag: the drawer marks the obs seen
+        # on open, so it no longer depends on the obs already being seen at GET
+        # time (audit M11). GET itself no longer mutates seen state.
+        can_be_marked_unseen = user.obs_match_alerts(obs)
 
     admin_url: str | None = None
     if request.user.is_authenticated and request.user.is_superuser:
@@ -642,6 +642,26 @@ def page_fragment(request: HttpRequest, identifier: str):
     except PageFragment.DoesNotExist:
         html = ""
     return {"html": html}
+
+
+@api_v2.post(
+    "/observations/{stable_id}/mark-as-seen/",
+    response={200: OkOut},
+    auth=django_auth,
+)
+def observation_mark_as_seen(request: HttpRequest, stable_id: str):
+    """Mark a single observation as seen by the requesting user.
+
+    Replaces the implicit side effect that the detail GET used to perform, so
+    that GET stays safe/idempotent (audit M11).
+    """
+    try:
+        obs = Observation.objects.get(stable_id=stable_id)
+    except Observation.DoesNotExist:
+        raise HttpError(404, "Observation not found")
+
+    obs.mark_as_seen_by(cast(User, request.user))
+    return 200, {"ok": True}
 
 
 @api_v2.post(

--- a/dashboard/tests/playwright/test_alerts.py
+++ b/dashboard/tests/playwright/test_alerts.py
@@ -428,6 +428,13 @@ def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server)
 
     # Open the drawer by clicking the species cell in the row.
     page.get_by_role("cell", name=re.compile("Procambarus fallax", re.I)).first.click()
+    # Wait for the drawer to actually open and its detail content to render before
+    # closing. networkidle alone is unreliable here: the page is already idle from
+    # load, so it resolves before the drawer fires its detail GET + mark-as-seen
+    # POST, and an immediate Escape would race (and cancel) those requests.
+    drawer = page.locator('[data-pc-name="drawer"]')
+    expect(drawer).to_be_visible()
+    expect(drawer.get_by_text("Procambarus fallax").first).to_be_visible()
     page.wait_for_load_state("networkidle")
 
     # Close the drawer (Escape works for PrimeVue Drawer).

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1047,6 +1047,20 @@ def test_observation_add_comment_anonymous_returns_401(client, observation_detai
     assert resp.status_code == 401
 
 
+def test_add_comment_empty_text_returns_422(client, observation_detail_data):
+    """Empty (whitespace-only) comment text is semantically invalid: 422 (N3)."""
+    obs = observation_detail_data["obs"]
+    user = observation_detail_data["user"]
+    client.force_login(user)
+    resp = client.post(
+        f"/api/v2/observations/{obs.stable_id}/comments/",
+        data={"text": "   "},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+    assert "detail" in resp.json()
+
+
 def test_observation_mark_unseen_anonymous_returns_401(client, observation_detail_data):
     """Anonymous users get 401 from mark-unseen, not 403."""
     obs = observation_detail_data["obs"]

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -459,6 +459,28 @@ def test_pagination_second_page(client, observations_data):
     assert id_p1 != id_p2
 
 
+def test_page_size_over_max_returns_400(client, observations_data):
+    resp = client.get(reverse("api-v2:observations_list"), {"pageSize": 101})
+    assert resp.status_code == 400
+    assert "pageSize" in resp.json()["detail"]
+
+
+def test_page_size_below_one_returns_400(client, observations_data):
+    resp = client.get(reverse("api-v2:observations_list"), {"pageSize": 0})
+    assert resp.status_code == 400
+
+
+def test_page_below_one_returns_400(client, observations_data):
+    resp = client.get(reverse("api-v2:observations_list"), {"page": 0})
+    assert resp.status_code == 400
+
+
+def test_page_size_at_max_is_accepted(client, observations_data):
+    """The boundary value 100 is still valid (no off-by-one)."""
+    resp = client.get(reverse("api-v2:observations_list"), {"pageSize": 100})
+    assert resp.status_code == 200
+
+
 # --- Filter wiring ---
 
 
@@ -836,25 +858,25 @@ def test_order_by_dataset_name_descending(client, sorting_data):
 # --- robustness ---
 
 
-def test_unknown_order_by_falls_back_to_date(client, sorting_data):
-    """An unrecognised orderBy value must not crash - falls back to date sort."""
-    obs_alpha = sorting_data["obs_alpha"]
-    obs_zeta = sorting_data["obs_zeta"]
+def test_unknown_order_by_returns_400(client, sorting_data):
+    """An unrecognised orderBy is rejected with 400 listing the accepted values (M8)."""
     response = client.get(
         reverse("api-v2:observations_list"), {"orderBy": "nonExistentField"}
     )
-    assert response.status_code == 200
-    # Default date-desc order: obs_zeta (newer) before obs_alpha (older)
-    ids = [item["id"] for item in response.json()["items"]]
-    assert ids.index(obs_zeta.pk) < ids.index(obs_alpha.pk)
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "orderBy" in detail
+    assert "date" in detail  # the accepted values are listed
 
 
-def test_unknown_order_dir_treated_as_desc(client, sorting_data):
-    """Any orderDir value other than 'asc' must be treated as descending."""
-    obs_alpha = sorting_data["obs_alpha"]
-    obs_zeta = sorting_data["obs_zeta"]
-    ids = _sorting_ids(client, orderBy="date", orderDir="INVALID")
-    assert ids.index(obs_zeta.pk) < ids.index(obs_alpha.pk)
+def test_unknown_order_dir_returns_400(client, sorting_data):
+    """An orderDir other than asc/desc is rejected with 400 (M8)."""
+    response = client.get(
+        reverse("api-v2:observations_list"),
+        {"orderBy": "date", "orderDir": "INVALID"},
+    )
+    assert response.status_code == 400
+    assert "orderDir" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1079,6 +1079,48 @@ def test_observation_mark_unseen_no_matching_alert_returns_403(
     assert resp.status_code == 403
 
 
+# --- M11: GET side-effect removal + single mark-as-seen ---
+
+
+def test_get_detail_does_not_mark_as_seen(client, observation_detail_data):
+    """A GET on the detail endpoint must not mutate per-user seen state (M11)."""
+    obs = observation_detail_data["obs"]
+    user = observation_detail_data["user"]
+    ObservationUnseen.objects.create(observation=obs, user=user)
+    client.force_login(user)
+    resp = client.get(f"/api/v2/observations/{obs.stable_id}/")
+    assert resp.status_code == 200
+    # The unseen marker is still there - the GET did not mark it seen.
+    assert ObservationUnseen.objects.filter(observation=obs, user=user).exists()
+    assert resp.json()["seenByCurrentUser"] is False
+
+
+def test_mark_as_seen_single_anonymous_returns_401(client, observation_detail_data):
+    obs = observation_detail_data["obs"]
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-seen/")
+    assert resp.status_code == 401
+
+
+def test_mark_as_seen_single_marks_observation_seen(client, observation_detail_data):
+    obs = observation_detail_data["obs"]
+    user = observation_detail_data["user"]
+    ObservationUnseen.objects.create(observation=obs, user=user)
+    client.force_login(user)
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-seen/")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert not ObservationUnseen.objects.filter(observation=obs, user=user).exists()
+
+
+def test_mark_as_seen_single_unknown_stable_id_returns_404(
+    client, observation_detail_data
+):
+    user = observation_detail_data["user"]
+    client.force_login(user)
+    resp = client.post("/api/v2/observations/does-not-exist/mark-as-seen/")
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # ApiV2ObservationsMunicipalityVerifiedSortTests fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fifth PR of the API v2 hygiene cleanup. Makes the observations endpoints behave
predictably for public consumers. Resolves M8, M11, N3 (+ the pageSize silent
clamp). Three commits.

- **M8 + pagination:** `observations_list` returns 400 for unknown `orderBy`,
  `orderDir` outside {asc,desc}, `pageSize` outside 1..100, and `page < 1`,
  instead of silently coercing/clamping. The SPA only ever sends valid values,
  so no client change.
- **N3:** empty comment text returns 422 (DetailErrorOut), matching area-create,
  instead of 400. The SPA disables submit on empty input + shows a generic error,
  so behaviour is unchanged for the client.
- **M11:** `GET /observations/{stable_id}/` no longer marks the observation as
  seen (GETs are now safe/idempotent). A new
  `POST /observations/{stable_id}/mark-as-seen/` (auth, `{ok: true}`) does it
  explicitly; the SPA drawer calls it on open. `canBeMarkedUnseen` drops its
  already-seen gate so the drawer button still appears (this field is removed in PR6).

## Notes

- The M11 commit also hardens the e2e test `test_alert_detail_drawer_refreshes_list_and_sidebar`:
  it relied on `networkidle` after the row-click, which resolves before the drawer
  fires its detail GET + mark-as-seen POST (the page is already idle from load).
  Splitting seen-marking into a later POST widened that race, so the test now waits
  for the drawer + its content to be visible before closing - matching the
  condition-based pattern already used in `test_index_page.py`.

## Test plan

- [x] Backend pytest: 414 passed (new 400/422/mark-as-seen tests + GET-no-side-effect regression)
- [x] mypy clean
- [x] Playwright: 82 passed (drawer open -> seen -> row drops on close; seen-column flows)
- [x] TS types regenerated; diff reviewed (new endpoint + 400/422 response shapes)

See the design doc + PR5 plan in the Obsidian project folder for the full 7-PR plan.