### PR TITLE
feat(api): slim AlertOut representation (PR6b of API hygiene)

### DIFF
--- a/assets/frontend/components/AlertCard.vue
+++ b/assets/frontend/components/AlertCard.vue
@@ -11,6 +11,7 @@ import SpeciesName from "./SpeciesName.vue";
 import type { components } from "../types/api";
 import { getCsrf } from "../utils/csrf";
 import { useAlertMeta } from "../composables/useAlertMeta";
+import { useDisplayLabels } from "../composables/useDisplayLabels";
 import { pickVernacular } from "../utils/vernacular";
 
 type AlertOut = components["schemas"]["AlertOut"];
@@ -19,6 +20,7 @@ const props = defineProps<{ alert: AlertOut }>();
 const emit = defineEmits<{ deleted: [] }>();
 
 const { t, locale } = useI18n();
+const { datasetName, frequencyLabel } = useDisplayLabels();
 const router = useRouter();
 const confirm = useConfirm();
 const toast = useToast();
@@ -104,13 +106,13 @@ function confirmDelete() {
             </div>
 
             <!-- Datasets (only when filtered) -->
-            <div v-if="alert.datasetNames.length > 0" class="section chips-row">
+            <div v-if="alert.datasetIds.length > 0" class="section chips-row">
                 <i class="pi pi-database meta-icon" />
                 <div class="chips">
                     <Tag
-                        v-for="name in alert.datasetNames"
-                        :key="name"
-                        :value="name"
+                        v-for="id in alert.datasetIds"
+                        :key="id"
+                        :value="datasetName(id)"
                         severity="secondary"
                         class="dataset-chip"
                     />
@@ -121,7 +123,7 @@ function confirmDelete() {
             <div class="section meta-row">
                 <i class="pi pi-bell meta-icon" />
                 <span>
-                    {{ alert.emailNotificationsFrequencyDisplay }}
+                    {{ frequencyLabel(alert.emailNotificationsFrequency) }}
                     &middot;
                     <span class="muted">{{ t("message.lastEmailSentAt") }} {{ formatDate(alert.lastEmailSentAt) }}</span>
                 </span>

--- a/assets/frontend/components/AlertCard.vue
+++ b/assets/frontend/components/AlertCard.vue
@@ -11,13 +11,14 @@ import SpeciesName from "./SpeciesName.vue";
 import type { components } from "../types/api";
 import { getCsrf } from "../utils/csrf";
 import { useAlertMeta } from "../composables/useAlertMeta";
+import { pickVernacular } from "../utils/vernacular";
 
 type AlertOut = components["schemas"]["AlertOut"];
 
 const props = defineProps<{ alert: AlertOut }>();
 const emit = defineEmits<{ deleted: [] }>();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const router = useRouter();
 const confirm = useConfirm();
 const toast = useToast();
@@ -76,7 +77,7 @@ function confirmDelete() {
                     <li v-for="sp in visibleSpecies" :key="sp.scientificName">
                         <SpeciesName
                             :scientific-name="sp.scientificName"
-                            :vernacular-name="sp.vernacularName ?? ''"
+                            :vernacular-name="pickVernacular(sp, locale)"
                         />
                     </li>
                 </ul>

--- a/assets/frontend/components/AlertSidebar.vue
+++ b/assets/frontend/components/AlertSidebar.vue
@@ -9,6 +9,7 @@ import Tag from "primevue/tag";
 import SpeciesName from "./SpeciesName.vue";
 import ObservationStatusToggle from "./ObservationStatusToggle.vue";
 import { useAlertMeta } from "../composables/useAlertMeta";
+import { pickVernacular } from "../utils/vernacular";
 import { useResultsStore } from "../stores/results";
 import { useFiltersStore } from "../stores/filters";
 import { getCsrf } from "../utils/csrf";
@@ -22,7 +23,7 @@ const props = defineProps<{
     alert: AlertOut;
 }>();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const router = useRouter();
 const isAuthenticated: boolean = getNavConfig().user.isAuthenticated;
 const confirm = useConfirm();
@@ -104,7 +105,7 @@ const formattedDatasetsCount = computed(() =>
                 <li v-for="sp in visibleSpecies" :key="sp.scientificName">
                     <SpeciesName
                         :scientific-name="sp.scientificName"
-                        :vernacular-name="sp.vernacularName ?? ''"
+                        :vernacular-name="pickVernacular(sp, locale)"
                     />
                 </li>
             </ul>

--- a/assets/frontend/components/AlertSidebar.vue
+++ b/assets/frontend/components/AlertSidebar.vue
@@ -9,6 +9,7 @@ import Tag from "primevue/tag";
 import SpeciesName from "./SpeciesName.vue";
 import ObservationStatusToggle from "./ObservationStatusToggle.vue";
 import { useAlertMeta } from "../composables/useAlertMeta";
+import { useDisplayLabels } from "../composables/useDisplayLabels";
 import { pickVernacular } from "../utils/vernacular";
 import { useResultsStore } from "../stores/results";
 import { useFiltersStore } from "../stores/filters";
@@ -33,6 +34,7 @@ const filtersStore = useFiltersStore();
 
 const { speciesExpanded, tooManySpecies, visibleSpecies, areaDescription, SPECIES_COLLAPSE_THRESHOLD } =
     useAlertMeta(() => props.alert);
+const { datasetName, basisOfRecordName } = useDisplayLabels();
 
 function confirmMarkAllAsViewed() {
     confirm.require({
@@ -135,13 +137,13 @@ const formattedDatasetsCount = computed(() =>
         </div>
 
         <!-- DATASETS section (hidden when no datasets configured) -->
-        <div v-if="alert.datasetNames.length > 0" class="sidebar-section">
+        <div v-if="alert.datasetIds.length > 0" class="sidebar-section">
             <div class="sidebar-section-heading"><i class="pi pi-database" />{{ t("message.dataset") }}</div>
             <div class="chips">
                 <Tag
-                    v-for="name in alert.datasetNames"
-                    :key="name"
-                    :value="name"
+                    v-for="id in alert.datasetIds"
+                    :key="id"
+                    :value="datasetName(id)"
                     severity="secondary"
                     class="dataset-chip"
                 />
@@ -149,11 +151,11 @@ const formattedDatasetsCount = computed(() =>
         </div>
 
         <!-- BASIS OF RECORD section (hidden when all) -->
-        <div v-if="alert.basisOfRecordList" class="sidebar-section">
+        <div v-if="alert.basisOfRecordIds.length > 0" class="sidebar-section">
             <div class="sidebar-section-heading"><i class="pi pi-tag" />{{ t("message.basisOfRecord") }}</div>
             <div class="meta-row">
                 <i class="pi pi-tag meta-icon" />
-                <span>{{ alert.basisOfRecordList }}</span>
+                <span>{{ alert.basisOfRecordIds.map(basisOfRecordName).join(", ") }}</span>
             </div>
         </div>
 

--- a/assets/frontend/composables/useAlertMeta.ts
+++ b/assets/frontend/composables/useAlertMeta.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from "vue";
 import { useI18n } from "vue-i18n";
 import type { components } from "../types/api";
+import { useDisplayLabels } from "./useDisplayLabels";
 
 type AlertOut = components["schemas"]["AlertOut"];
 
@@ -8,6 +9,7 @@ const SPECIES_COLLAPSE_THRESHOLD = 4;
 
 export function useAlertMeta(alert: () => AlertOut) {
     const { t } = useI18n();
+    const { areaName } = useDisplayLabels();
 
     const speciesExpanded = ref(false);
 
@@ -22,7 +24,8 @@ export function useAlertMeta(alert: () => AlertOut) {
     );
 
     const areaDescription = computed(() => {
-        const names = alert().areaNames;
+        // areaNames was dropped from AlertOut (N5); derive from areaIds.
+        const names = alert().areaIds.map((id) => areaName(id)).filter(Boolean);
         if (names.length === 0) return "";
         const quoted = names.map((n) => `'${n}'`);
         const areas =

--- a/assets/frontend/composables/useDisplayLabels.ts
+++ b/assets/frontend/composables/useDisplayLabels.ts
@@ -1,12 +1,12 @@
 import { useFilterOptionsStore } from "../stores/filterOptions";
 
-// Resolves option ids (currently basis-of-record) to their human-readable names
-// for the observation table and detail drawer. The backend now returns ids
-// instead of pre-formatted labels (audit N7), so the SPA does the join.
+// Resolves option ids (and the email-frequency enum) to their human-readable
+// names. The backend now returns ids instead of pre-formatted labels (audit
+// N5/N7), so the SPA does the join.
 //
-// ObservationsView renders on the alert detail page too, which has no
-// FilterSidebar to populate the option lists, so the list is loaded lazily.
-// PR6b extends this composable with datasets/areas/frequencies for the alert pages.
+// Lists are loaded lazily: ObservationsView renders on the alert detail page
+// and the alert pages render cards/sidebars, none of which have a FilterSidebar
+// to populate filterOptionsStore. Each loader is load-if-empty (idempotent).
 export function useDisplayLabels() {
     const store = useFilterOptionsStore();
 
@@ -16,9 +16,57 @@ export function useDisplayLabels() {
         if (res.ok) store.basisOfRecord = await res.json();
     }
 
+    async function ensureDatasetsLoaded(): Promise<void> {
+        if (store.datasets.length) return;
+        const res = await fetch("/api/v2/datasets/");
+        if (res.ok) store.datasets = await res.json();
+    }
+
+    async function ensureAreasLoaded(): Promise<void> {
+        if (store.areas.length) return;
+        const res = await fetch("/api/v2/areas/");
+        if (res.ok) store.areas = await res.json();
+    }
+
+    async function ensureFrequenciesLoaded(): Promise<void> {
+        if (store.frequencies.length) return;
+        const res = await fetch("/api/v2/alerts/notification-frequencies/");
+        if (res.ok) store.frequencies = await res.json();
+    }
+
+    // The lookup lists the alert pages need to render an alert's filters.
+    async function ensureAlertLabelsLoaded(): Promise<void> {
+        await Promise.all([
+            ensureDatasetsLoaded(),
+            ensureAreasLoaded(),
+            ensureBasisOfRecordLoaded(),
+            ensureFrequenciesLoaded(),
+        ]);
+    }
+
     function basisOfRecordName(id: number): string {
         return store.basisOfRecord.find((b) => b.id === id)?.name ?? "";
     }
 
-    return { ensureBasisOfRecordLoaded, basisOfRecordName };
+    function datasetName(id: number): string {
+        return store.datasets.find((d) => d.id === id)?.name ?? "";
+    }
+
+    function areaName(id: number): string {
+        return store.areas.find((a) => a.id === id)?.name ?? "";
+    }
+
+    // Frequencies are keyed by their enum code (e.g. "W"); fall back to the code.
+    function frequencyLabel(id: string): string {
+        return store.frequencies.find((f) => f.id === id)?.label ?? id;
+    }
+
+    return {
+        ensureBasisOfRecordLoaded,
+        ensureAlertLabelsLoaded,
+        basisOfRecordName,
+        datasetName,
+        areaName,
+        frequencyLabel,
+    };
 }

--- a/assets/frontend/pages/AlertDetailPage.vue
+++ b/assets/frontend/pages/AlertDetailPage.vue
@@ -9,6 +9,7 @@ import type { components } from "../types/api";
 import { useFiltersStore } from "../stores/filters";
 import { useResultsStore } from "../stores/results";
 import { getNavConfig } from "../utils/navConfig";
+import { useDisplayLabels } from "../composables/useDisplayLabels";
 
 type AlertOut = components["schemas"]["AlertOut"];
 
@@ -17,6 +18,7 @@ const route = useRoute();
 const router = useRouter();
 const filtersStore = useFiltersStore();
 const resultsStore = useResultsStore();
+const { ensureAlertLabelsLoaded } = useDisplayLabels();
 
 const alertId = Number(route.params.alertId);
 
@@ -37,6 +39,8 @@ async function fetchAlert(): Promise<void> {
 
 onMounted(async () => {
     alertLoading.value = true;
+    // The sidebar resolves dataset/area/basis ids -> names locally now (N5).
+    ensureAlertLabelsLoaded();
     try {
         await fetchAlert();
         if (!alert.value) return;

--- a/assets/frontend/pages/UserAlertsPage.vue
+++ b/assets/frontend/pages/UserAlertsPage.vue
@@ -6,11 +6,13 @@ import Button from "primevue/button";
 import AlertCard from "../components/AlertCard.vue";
 import type { components } from "../types/api";
 import { getNavConfig } from "../utils/navConfig";
+import { useDisplayLabels } from "../composables/useDisplayLabels";
 
 type AlertOut = components["schemas"]["AlertOut"];
 
 const { t } = useI18n();
 const router = useRouter();
+const { ensureAlertLabelsLoaded } = useDisplayLabels();
 
 const alerts = ref<AlertOut[]>([]);
 const loading = ref(false);
@@ -29,7 +31,11 @@ async function loadAlerts() {
 const navConfig = getNavConfig();
 document.title = `${t("message.navMyAlerts")} - ${navConfig.siteName}`;
 
-onMounted(loadAlerts);
+onMounted(() => {
+    // The cards resolve dataset/area/basis/frequency ids -> names locally now (N5).
+    ensureAlertLabelsLoaded();
+    loadAlerts();
+});
 </script>
 
 <template>

--- a/assets/frontend/stores/filterOptions.ts
+++ b/assets/frontend/stores/filterOptions.ts
@@ -6,15 +6,18 @@ type SpeciesOut = components["schemas"]["SpeciesOut"];
 type DatasetOut = components["schemas"]["DatasetOut"];
 type AreaOut = components["schemas"]["AreaOut"];
 type BasisOfRecordOut = components["schemas"]["BasisOfRecordOut"];
+type AlertNotificationFrequencyOut =
+    components["schemas"]["AlertNotificationFrequencyOut"];
 
-// Holds the option lists loaded by FilterSidebar so that sibling components
-// (e.g. ActiveFilterChips) can resolve IDs to human-readable names without
-// making duplicate API requests.
+// Cache of lookup lists so components can resolve IDs (and enum codes) to
+// human-readable names without duplicate requests. Populated by FilterSidebar
+// (index page) and, for the alert pages, by useDisplayLabels.ensureAlertLabelsLoaded().
 export const useFilterOptionsStore = defineStore("filterOptions", () => {
     const species = ref<SpeciesOut[]>([]);
     const datasets = ref<DatasetOut[]>([]);
     const areas = ref<AreaOut[]>([]);
     const basisOfRecord = ref<BasisOfRecordOut[]>([]);
+    const frequencies = ref<AlertNotificationFrequencyOut[]>([]);
 
-    return { species, datasets, areas, basisOfRecord };
+    return { species, datasets, areas, basisOfRecord, frequencies };
 });

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -876,8 +876,12 @@ export interface components {
         AlertSpeciesOut: {
             /** Scientificname */
             scientificName: string;
-            /** Vernacularname */
-            vernacularName: string;
+            /** Vernacularnameen */
+            vernacularNameEn: string;
+            /** Vernacularnamenl */
+            vernacularNameNl: string;
+            /** Vernacularnamefr */
+            vernacularNameFr: string;
         };
         /**
          * ValidationErrorOut

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -853,22 +853,6 @@ export interface components {
             unseenCount: number;
             /** Speciesdetails */
             speciesDetails: components["schemas"]["AlertSpeciesOut"][];
-            /** Specieslist */
-            speciesList: string;
-            /** Areadescription */
-            areaDescription: string;
-            /** Areanames */
-            areaNames: string[];
-            /** Datasetnames */
-            datasetNames: string[];
-            /** Datasetslist */
-            datasetsList: string;
-            /** Basisofrecordlist */
-            basisOfRecordList: string;
-            /** Verifiedfilterdisplay */
-            verifiedFilterDisplay: string;
-            /** Emailnotificationsfrequencydisplay */
-            emailNotificationsFrequencyDisplay: string;
             /** Lastemailsentat */
             lastEmailSentAt: string | null;
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -713,7 +713,7 @@ def _alert_to_out(alert: Alert) -> dict:
         "approachingDistanceKm": alert.approaching_distance_km,
         "unseenCount": alert.unseen_observations().count(),
         "speciesDetails": [
-            {"scientificName": s.name, "vernacularName": s.vernacular_name}
+            {"scientificName": s.name, **_vernacular_names(s)}
             for s in alert.species.all()
         ],
         "speciesList": alert.species_list,

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -716,16 +716,6 @@ def _alert_to_out(alert: Alert) -> dict:
             {"scientificName": s.name, **_vernacular_names(s)}
             for s in alert.species.all()
         ],
-        "speciesList": alert.species_list,
-        "areaDescription": alert.area_description,
-        "areaNames": list(alert.areas.order_by("name").values_list("name", flat=True)),
-        "datasetNames": list(
-            alert.datasets.order_by("name").values_list("name", flat=True)
-        ),
-        "datasetsList": alert.datasets_list,
-        "basisOfRecordList": alert.basis_of_record_list,
-        "verifiedFilterDisplay": alert.verified_filter_display,
-        "emailNotificationsFrequencyDisplay": alert.get_email_notifications_frequency_display(),
         "lastEmailSentAt": alert.last_email_sent_on,
     }
 

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -168,7 +168,9 @@ class AlertIn(Schema):
 
 class AlertSpeciesOut(Schema):
     scientificName: str
-    vernacularName: str
+    vernacularNameEn: str
+    vernacularNameNl: str
+    vernacularNameFr: str
 
 
 class AlertOut(Schema):

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -186,14 +186,6 @@ class AlertOut(Schema):
     approachingDistanceKm: float | None
     unseenCount: int
     speciesDetails: list[AlertSpeciesOut]
-    speciesList: str
-    areaDescription: str
-    areaNames: list[str]
-    datasetNames: list[str]
-    datasetsList: str
-    basisOfRecordList: str
-    verifiedFilterDisplay: str
-    emailNotificationsFrequencyDisplay: str
     lastEmailSentAt: datetime.datetime | None
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1360,6 +1360,17 @@ def test_alert_detail_returns_correct_fields(client, alert_data):
     assert "emailNotificationsFrequencyDisplay" in data
 
 
+def test_alert_species_details_have_three_vernacular_languages(client, alert_data):
+    """AlertOut.speciesDetails carries vernacularNameEn/Nl/Fr (N6 follow-up)."""
+    alert = alert_data["alert"]
+    client.login(username="alertuser", password="12345")
+    sd = client.get(f"/api/v2/alerts/{alert.pk}/").json()["speciesDetails"][0]
+    assert "vernacularNameEn" in sd
+    assert "vernacularNameNl" in sd
+    assert "vernacularNameFr" in sd
+    assert "vernacularName" not in sd
+
+
 def test_alert_detail_wrong_user_returns_404(client, alert_data):
     alert = alert_data["alert"]
     client.login(username="otheruser", password="12345")

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1356,8 +1356,21 @@ def test_alert_detail_returns_correct_fields(client, alert_data):
     data = response.json()
     assert data["name"] == "My alert #1"
     assert data["speciesIds"] == [sp1.pk]
-    assert "speciesList" in data
-    assert "emailNotificationsFrequencyDisplay" in data
+    # N5: AlertOut carries raw ids/enums, not pre-formatted display strings.
+    for dropped in (
+        "speciesList",
+        "datasetsList",
+        "basisOfRecordList",
+        "verifiedFilterDisplay",
+        "emailNotificationsFrequencyDisplay",
+        "areaDescription",
+        "datasetNames",
+        "areaNames",
+    ):
+        assert dropped not in data, f"{dropped} should have been dropped from AlertOut"
+    assert data["datasetIds"] == []
+    assert "emailNotificationsFrequency" in data
+    assert "speciesDetails" in data
 
 
 def test_alert_species_details_have_three_vernacular_languages(client, alert_data):


### PR DESCRIPTION
## Summary

PR6b of the API v2 hygiene cleanup - the alert-pages half of PR6 (PR6a covered
observations/species, #324). Resolves N5 and applies the N6 vernacular treatment
to AlertSpeciesOut.

- **AlertSpeciesOut vernacular:** `speciesDetails[]` now carries
  `vernacularNameEn/Nl/Fr` instead of a single locale-dependent `vernacularName`;
  the alert card/sidebar pick the active locale via `pickVernacular()`.
- **N5 - slim AlertOut:** drops `speciesList`, `datasetsList`, `basisOfRecordList`,
  `verifiedFilterDisplay`, `emailNotificationsFrequencyDisplay`, `areaDescription`,
  `datasetNames`, `areaNames` - locale-dependent display strings that don't belong
  in the resource. Kept: raw ids/enums, `unseenCount`, `lastEmailSentAt`, and
  `speciesDetails` (so alert pages don't need to load the full `/species/` list).

The SPA now owns the id->label join: `useDisplayLabels` is extended with
dataset/area/frequency lookups (on top of basis from PR6a) and an
`ensureAlertLabelsLoaded()` that lazily loads the four small lists; both alert
pages call it on mount, and `useAlertMeta` derives `areaNames` from `areaIds`.
Four of the eight dropped fields were already dead in the SPA.

## Decisions
- **speciesDetails kept** (not dropped for full "raw ids only") - avoids loading
  the entire species list just for names on alert pages.
- **M10 (`canBeMarkedUnseen`) remains declined** (kept server-side; geo matching
  the SPA can't replicate).

## Test plan
- [x] Backend pytest: 417 passed (AlertOut-slim + speciesDetails-3-lang tests, repointed assertions)
- [x] mypy clean
- [x] Playwright: 82 passed (alert list cards + detail sidebar render species/datasets/basis/area/frequency from the lazily-loaded lists; drawer-refresh)
- [x] TS types regenerated; diff drops the 8 fields

With PR6b, PR6 is complete. Remaining: PR7 (legacy /api migration).