### PR TITLE
feat(api): mark/area hygiene (PR7a of API hygiene)

### DIFF
--- a/assets/frontend/components/AlertSidebar.vue
+++ b/assets/frontend/components/AlertSidebar.vue
@@ -14,7 +14,7 @@ import { pickVernacular } from "../utils/vernacular";
 import { useResultsStore } from "../stores/results";
 import { useFiltersStore } from "../stores/filters";
 import { getCsrf } from "../utils/csrf";
-import { filtersToParams } from "../utils/filterParams";
+import { filtersToBody } from "../utils/filterParams";
 import type { components } from "../types/api";
 import { getNavConfig } from "../utils/navConfig";
 
@@ -43,13 +43,14 @@ function confirmMarkAllAsViewed() {
         acceptLabel: t("message.yesImSure"),
         rejectLabel: t("message.cancel"),
         accept: async () => {
-            const resp = await fetch(
-                `/api/v2/observations/mark-as-seen/?${filtersToParams(filtersStore)}`,
-                {
-                    method: "POST",
-                    headers: { "X-CSRFToken": getCsrf() },
-                }
-            );
+            const resp = await fetch("/api/v2/observations/mark-as-seen/", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": getCsrf(),
+                },
+                body: JSON.stringify(filtersToBody(filtersStore)),
+            });
             if (!resp.ok) return;
             toast.add({
                 severity: "success",

--- a/assets/frontend/components/ObservationDetailPanel.vue
+++ b/assets/frontend/components/ObservationDetailPanel.vue
@@ -89,7 +89,7 @@ async function submitComment() {
 async function markUnseen() {
     markingUnseen.value = true;
     try {
-        const resp = await fetch(`/api/v2/observations/${props.stableId}/mark-unseen/`, {
+        const resp = await fetch(`/api/v2/observations/${props.stableId}/mark-as-unseen/`, {
             method: "POST",
             headers: { "X-CSRFToken": getCsrf() },
         });

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -295,7 +295,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/observations/{stable_id}/mark-unseen/": {
+    "/api/v2/observations/{stable_id}/mark-as-unseen/": {
         parameters: {
             query?: never;
             header?: never;
@@ -304,8 +304,8 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Observation Mark Unseen */
-        post: operations["dashboard_api_v2_observation_mark_unseen"];
+        /** Observation Mark As Unseen */
+        post: operations["dashboard_api_v2_observation_mark_as_unseen"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1447,7 +1447,7 @@ export interface operations {
             };
         };
     };
-    dashboard_api_v2_observation_mark_unseen: {
+    dashboard_api_v2_observation_mark_as_unseen: {
         parameters: {
             query?: never;
             header?: never;

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -122,13 +122,13 @@ export interface paths {
         put?: never;
         post?: never;
         /**
-         * Area Delete Endpoint
+         * Area Delete
          * @description Delete a user-owned area.
          *
          *     Returns 404 if the area does not exist or belongs to another user.
          *     Returns 409 with a detail message if any alerts reference this area.
          */
-        delete: operations["dashboard_api_v2_area_delete_endpoint"];
+        delete: operations["dashboard_api_v2_area_delete"];
         options?: never;
         head?: never;
         /**
@@ -1163,7 +1163,7 @@ export interface operations {
             };
         };
     };
-    dashboard_api_v2_area_delete_endpoint: {
+    dashboard_api_v2_area_delete: {
         parameters: {
             query?: never;
             header?: never;

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -228,8 +228,11 @@ export interface paths {
         put?: never;
         /**
          * Observations Mark All As Seen
-         * @description Bulk-mark all observations matching the current filters as seen by
-         *     the requesting user. Runs asynchronously via django-rq.
+         * @description Bulk-mark all observations matching the given filters as seen by the
+         *     requesting user. Runs asynchronously via django-rq.
+         *
+         *     Filters are read from the JSON request body (a mutating POST carries its
+         *     payload in the body, not the query string - audit N4).
          */
         post: operations["dashboard_api_v2_observations_mark_all_as_seen"];
         delete?: never;
@@ -725,10 +728,15 @@ export interface components {
         /**
          * QueuedOut
          * @description Acknowledgement that a bulk operation was queued for async processing.
+         *
+         *     `count` is the number of rows the operation will affect (e.g. matching
+         *     observations currently unseen by the user, for bulk mark-as-seen).
          */
         QueuedOut: {
             /** Queued */
             queued: boolean;
+            /** Count */
+            count: number;
         };
         /** CommentOut */
         CommentOut: {
@@ -1338,24 +1346,16 @@ export interface operations {
     };
     dashboard_api_v2_observations_mark_all_as_seen: {
         parameters: {
-            query?: {
-                speciesIds?: number[];
-                datasetIds?: number[];
-                basisOfRecordIds?: number[];
-                startDate?: string | null;
-                endDate?: string | null;
-                areaIds?: number[];
-                status?: string | null;
-                initialDataImportIds?: number[];
-                verifiedFilter?: string;
-                areaFilterMode?: string;
-                approachingDistanceKm?: number | null;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FiltersQuery"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {

--- a/assets/frontend/utils/filterParams.ts
+++ b/assets/frontend/utils/filterParams.ts
@@ -1,6 +1,8 @@
 import type { useFiltersStore } from "../stores/filters";
+import type { components } from "../types/api";
 
 type FiltersStore = ReturnType<typeof useFiltersStore>;
+type FiltersQuery = components["schemas"]["FiltersQuery"];
 
 /**
  * Serialize the current filters store into URLSearchParams suitable for the
@@ -38,4 +40,25 @@ export function filtersToParams(
         );
     }
     return params;
+}
+
+/**
+ * Serialize the filters store into a FiltersQuery JSON body, for the mutating
+ * POST endpoints that take their filters in the request body (e.g. bulk
+ * mark-as-seen - audit N4).
+ */
+export function filtersToBody(filtersStore: FiltersStore): FiltersQuery {
+    return {
+        speciesIds: filtersStore.speciesIds,
+        datasetIds: filtersStore.datasetIds,
+        basisOfRecordIds: filtersStore.basisOfRecordIds,
+        areaIds: filtersStore.areaIds,
+        initialDataImportIds: filtersStore.initialDataImportIds,
+        startDate: filtersStore.startDate,
+        endDate: filtersStore.endDate,
+        status: filtersStore.status,
+        verifiedFilter: filtersStore.verifiedFilter,
+        areaFilterMode: filtersStore.areaFilterMode,
+        approachingDistanceKm: filtersStore.approachingDistanceKm,
+    };
 }

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -287,7 +287,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
     response={204: None, 409: DetailErrorOut},
     auth=django_auth,
 )
-def area_delete_endpoint(request: HttpRequest, area_id: int):
+def area_delete(request: HttpRequest, area_id: int):
     """Delete a user-owned area.
 
     Returns 404 if the area does not exist or belongs to another user.

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -520,9 +520,13 @@ def observations_histogram(request: HttpRequest, filters: Query[FiltersQuery]):
     response={200: QueuedOut},
     auth=django_auth,
 )
-def observations_mark_all_as_seen(request: HttpRequest, filters: Query[FiltersQuery]):
-    """Bulk-mark all observations matching the current filters as seen by
-    the requesting user. Runs asynchronously via django-rq."""
+def observations_mark_all_as_seen(request: HttpRequest, filters: FiltersQuery):
+    """Bulk-mark all observations matching the given filters as seen by the
+    requesting user. Runs asynchronously via django-rq.
+
+    Filters are read from the JSON request body (a mutating POST carries its
+    payload in the body, not the query string - audit N4).
+    """
     user = cast(User, request.user)
     qs = Observation.objects.filtered_from_my_params(
         species_ids=filters.speciesIds,
@@ -538,8 +542,11 @@ def observations_mark_all_as_seen(request: HttpRequest, filters: Query[FiltersQu
         area_filter_mode=filters.areaFilterMode,
         approaching_distance_km=filters.approachingDistanceKm,
     )
+    # N2: report how many matching observations are currently unseen by the user
+    # (the rows the job will actually flip), so the consumer knows what happened.
+    count = qs.filter(observationunseen__user=user).distinct().count()
     background_jobs.mark_many_observations_as_seen.delay(qs, user)
-    return 200, {"queued": True}
+    return 200, {"queued": True, "count": count}
 
 
 @api_v2.get("/observations/{stable_id}/", response=ObservationDetailOut)

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -679,11 +679,11 @@ def observation_mark_as_seen(request: HttpRequest, stable_id: str):
 
 
 @api_v2.post(
-    "/observations/{stable_id}/mark-unseen/",
+    "/observations/{stable_id}/mark-as-unseen/",
     response={200: OkOut, 403: DetailErrorOut},
     auth=django_auth,
 )
-def observation_mark_unseen(request: HttpRequest, stable_id: str):
+def observation_mark_as_unseen(request: HttpRequest, stable_id: str):
     try:
         obs = Observation.objects.get(stable_id=stable_id)
     except Observation.DoesNotExist:

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -269,9 +269,14 @@ class ValidationErrorOut(Schema):
 
 
 class QueuedOut(Schema):
-    """Acknowledgement that a bulk operation was queued for async processing."""
+    """Acknowledgement that a bulk operation was queued for async processing.
+
+    `count` is the number of rows the operation will affect (e.g. matching
+    observations currently unseen by the user, for bulk mark-as-seen).
+    """
 
     queued: bool
+    count: int
 
 
 class OkOut(Schema):

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1101,7 +1101,7 @@ def test_add_comment_empty_text_returns_422(client, observation_detail_data):
 def test_observation_mark_unseen_anonymous_returns_401(client, observation_detail_data):
     """Anonymous users get 401 from mark-unseen, not 403."""
     obs = observation_detail_data["obs"]
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-unseen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-unseen/")
     assert resp.status_code == 401
 
 
@@ -1112,7 +1112,7 @@ def test_observation_mark_unseen_no_matching_alert_returns_403(
     user = observation_detail_data["user"]
     obs = observation_detail_data["obs"]
     client.force_login(user)
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-unseen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-unseen/")
     assert resp.status_code == 403
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2063,13 +2063,36 @@ def test_mark_all_as_seen_authenticated_returns_queued(
 
     user = observations_data["user"]
     client.force_login(user)
-    resp = client.post("/api/v2/observations/mark-as-seen/")
+    resp = client.post(
+        "/api/v2/observations/mark-as-seen/", data={}, content_type="application/json"
+    )
 
     assert resp.status_code == 200
-    assert resp.json() == {"queued": True}
+    # count = matching observations currently UNSEEN by the user (N2). The fixture
+    # creates no ObservationUnseen rows, so nothing is newly-marked here.
+    assert resp.json() == {"queued": True, "count": 0}
     assert len(calls) == 1
-    assert calls[0]["count"] == 2  # both observations in the fixture
+    assert calls[0]["count"] == 2  # the job still receives both matching observations
     assert calls[0]["user_id"] == user.pk
+
+
+def test_mark_all_as_seen_returns_count_of_unseen(client, observations_data, monkeypatch):
+    """count reports how many matching observations were unseen (N2)."""
+    from dashboard.views import jobs
+
+    monkeypatch.setattr(jobs.mark_many_observations_as_seen, "delay", lambda qs, u: None)
+
+    user = observations_data["user"]
+    for o in (observations_data["obs"], observations_data["obs_other_species"]):
+        ObservationUnseen.objects.create(observation=o, user=user)
+    client.force_login(user)
+    resp = client.post(
+        "/api/v2/observations/mark-as-seen/",
+        data={"status": "all"},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"queued": True, "count": 2}
 
 
 def test_mark_all_as_seen_respects_species_filter(
@@ -2091,7 +2114,11 @@ def test_mark_all_as_seen_respects_species_filter(
     other_obs = observations_data["obs_other_species"]
 
     client.force_login(user)
-    resp = client.post(f"/api/v2/observations/mark-as-seen/?speciesIds={species.pk}")
+    resp = client.post(
+        "/api/v2/observations/mark-as-seen/",
+        data={"speciesIds": [species.pk]},
+        content_type="application/json",
+    )
 
     assert resp.status_code == 200
     assert captured["ids"] == [target_obs.pk]
@@ -2256,7 +2283,7 @@ def test_simple_dict_out_schemas_shapes():
         QueuedOut,
     )
 
-    assert QueuedOut(queued=True).queued is True
+    assert QueuedOut(queued=True, count=0).queued is True
     assert OkOut(ok=True).ok is True
     assert PageFragmentOut(html="<p>hi</p>").html == "<p>hi</p>"
     assert AlertNameSuggestionOut(name="My alert #1").name == "My alert #1"


### PR DESCRIPTION
## Summary

PR7a of the API v2 hygiene cleanup - the v2-internal half of PR7 (the legacy
`/api/...` migration is the separate PR7b). The SPA consumes no legacy `/api/*`
endpoint, so this is the only PR7 work that touches the client.

- **N8:** single `mark-unseen` -> `mark-as-unseen`, so the per-observation toggle
  pair reads `mark-as-seen` / `mark-as-unseen` (mirrors the bulk path). SPA drawer
  caller updated.
- **N4:** bulk `mark-as-seen` reads its `FiltersQuery` from the JSON request body
  instead of the query string (a mutating POST should carry its payload in the
  body; also dodges URL-length limits). SPA posts via a new `filtersToBody()`.
- **N2:** the bulk response gains `count` - matching observations currently
  unseen by the user (the rows the job will actually flip).
- **N11:** `area_delete_endpoint` -> `area_delete` so the OpenAPI operationId
  isn't awkward (path unchanged).
- **N12:** already resolved in PR3 (news/mark-visited moved to `/api/v2/spa/`).

## Test plan
- [x] Backend pytest: 418 passed (renamed path, body-filter bulk mark, count value)
- [x] mypy clean
- [x] Playwright: 82 passed (drawer mark-as-unseen, alert "mark all as viewed" via body POST)
- [x] TS types regenerated; diff = renamed path + operationId + count field

PR7b (legacy `/api/...` migration + Deprecation/Sunset headers; external-only)
follows as a separate PR.