### PR TITLE
feat(api): legacy /api migration + deprecation (PR7b of API hygiene)

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -21,6 +21,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/species/per-polygon/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Species Per Polygon
+         * @description Species occurring within the given polygon, each with its observation count.
+         *
+         *     The polygon is a GeoJSON FeatureCollection in EPSG:4326, sent in the request
+         *     body. (The legacy endpoint took WKT in the query string - audit N1.)
+         */
+        post: operations["dashboard_api_v2_species_per_polygon"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/datasets/": {
         parameters: {
             query?: never;
@@ -539,6 +562,48 @@ export interface components {
             /** Tags */
             tags: string[];
         };
+        /** SpeciesPerPolygonOut */
+        SpeciesPerPolygonOut: {
+            /** Id */
+            id: number;
+            /** Scientificname */
+            scientificName: string;
+            /** Vernacularnameen */
+            vernacularNameEn: string;
+            /** Vernacularnamenl */
+            vernacularNameNl: string;
+            /** Vernacularnamefr */
+            vernacularNameFr: string;
+            /**
+             * Gbiftaxonkey
+             * @description GBIF taxon key. Numeric in GBIF's data model, so returned as an integer. Distinct from `gbifId` (an occurrence identifier) which GBIF models as a string - the int/str split is intrinsic to GBIF, not an inconsistency in this API.
+             */
+            gbifTaxonKey: number;
+            /** Tags */
+            tags: string[];
+            /** Observationcountinpolygon */
+            observationCountInPolygon: number;
+        };
+        /**
+         * DetailErrorOut
+         * @description Single-message error envelope.
+         *
+         *     Used for all 4xx responses that do not carry per-field validation details.
+         *     Equivalent in shape to django-ninja's default error body, made explicit so
+         *     every endpoint declares it in its `response={...}` map and it appears in
+         *     the OpenAPI schema.
+         */
+        DetailErrorOut: {
+            /** Detail */
+            detail: string;
+        };
+        /** SpeciesPerPolygonIn */
+        SpeciesPerPolygonIn: {
+            /** Geojson */
+            geojson: {
+                [key: string]: unknown;
+            };
+        };
         /** DatasetOut */
         DatasetOut: {
             /** Id */
@@ -558,19 +623,6 @@ export interface components {
             isUserSpecific: boolean;
             /** Tags */
             tags: string[];
-        };
-        /**
-         * DetailErrorOut
-         * @description Single-message error envelope.
-         *
-         *     Used for all 4xx responses that do not carry per-field validation details.
-         *     Equivalent in shape to django-ninja's default error body, made explicit so
-         *     every endpoint declares it in its `response={...}` map and it appears in
-         *     the OpenAPI schema.
-         */
-        DetailErrorOut: {
-            /** Detail */
-            detail: string;
         };
         /**
          * GeoJSONFeatureCollectionOut
@@ -1055,6 +1107,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SpeciesOut"][];
+                };
+            };
+        };
+    };
+    dashboard_api_v2_species_per_polygon: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SpeciesPerPolygonIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SpeciesPerPolygonOut"][];
+                };
+            };
+            /** @description Unprocessable Entity */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -217,6 +217,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/observations/counter/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Observations Counter
+         * @description Return only the count of observations matching the filters - a lightweight
+         *     alternative to the full list when the consumer just needs the number.
+         *
+         *     Defined before observation_detail so the literal `/observations/counter/`
+         *     path is matched ahead of `/observations/{stable_id}/`.
+         */
+        get: operations["dashboard_api_v2_observations_counter"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/observations/mark-as-seen/": {
         parameters: {
             query?: never;
@@ -722,6 +746,14 @@ export interface components {
             year: number;
             /** Month */
             month: number;
+            /** Count */
+            count: number;
+        };
+        /**
+         * CountOut
+         * @description The number of observations matching a filter set.
+         */
+        CountOut: {
             /** Count */
             count: number;
         };
@@ -1340,6 +1372,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HistogramEntryOut"][];
+                };
+            };
+        };
+    };
+    dashboard_api_v2_observations_counter: {
+        parameters: {
+            query?: {
+                speciesIds?: number[];
+                datasetIds?: number[];
+                basisOfRecordIds?: number[];
+                startDate?: string | null;
+                endDate?: string | null;
+                areaIds?: number[];
+                status?: string | null;
+                initialDataImportIds?: number[];
+                verifiedFilter?: string;
+                areaFilterMode?: string;
+                approachingDistanceKm?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CountOut"];
                 };
             };
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -5,7 +5,11 @@ from typing import Annotated, cast
 
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout, update_session_auth_hash
-from django.contrib.gis.geos import GEOSGeometry, MultiPolygon as GEOSMultiPolygon
+from django.contrib.gis.geos import (
+    GEOSException,
+    GEOSGeometry,
+    MultiPolygon as GEOSMultiPolygon,
+)
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.serializers import serialize
 from django.db.models import Count, F, Value
@@ -49,6 +53,8 @@ from dashboard.api_v2_schemas import (
     SignInOut,
     SignUpIn,
     SpeciesOut,
+    SpeciesPerPolygonIn,
+    SpeciesPerPolygonOut,
     ValidationErrorOut,
 )
 from dashboard.forms import SignUpForm, _days_to_value_unit, _value_unit_to_days
@@ -155,6 +161,40 @@ def species_list(request: HttpRequest):
             "tags": [t.name for t in s.tags.all()],
         }
         for s in Species.objects.prefetch_related("tags").all()
+    ]
+
+
+@api_v2.post(
+    "/species/per-polygon/",
+    response={200: list[SpeciesPerPolygonOut], 422: DetailErrorOut},
+)
+def species_per_polygon(request: HttpRequest, payload: SpeciesPerPolygonIn):
+    """Species occurring within the given polygon, each with its observation count.
+
+    The polygon is a GeoJSON FeatureCollection in EPSG:4326, sent in the request
+    body. (The legacy endpoint took WKT in the query string - audit N1.)
+    """
+    try:
+        # Returns a geometry already projected to DATA_SRID (matches location).
+        mpoly = geojson_to_multipolygon(payload.geojson)
+    except (ValueError, KeyError, TypeError, GEOSException) as exc:
+        return 422, {"detail": f"Invalid GeoJSON: {exc}"}
+
+    qs = (
+        Species.objects.filter(observation__location__within=mpoly)
+        .annotate(num_observations=Count("observation"))
+        .prefetch_related("tags")
+    )
+    return 200, [
+        {
+            "id": s.pk,
+            "scientificName": s.name,
+            **_vernacular_names(s),
+            "gbifTaxonKey": s.gbif_taxon_key,
+            "tags": [t.name for t in s.tags.all()],
+            "observationCountInPolygon": s.num_observations,
+        }
+        for s in qs
     ]
 
 

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -30,6 +30,7 @@ from dashboard.api_v2_schemas import (
     BasisOfRecordOut,
     CommentIn,
     CommentOut,
+    CountOut,
     DataImportOut,
     DatasetOut,
     DetailErrorOut,
@@ -513,6 +514,32 @@ def observations_histogram(request: HttpRequest, filters: Query[FiltersQuery]):
         {"year": row["month"].year, "month": row["month"].month, "count": row["total"]}
         for row in rows
     ]
+
+
+@api_v2.get("/observations/counter/", response=CountOut)
+def observations_counter(request: HttpRequest, filters: Query[FiltersQuery]):
+    """Return only the count of observations matching the filters - a lightweight
+    alternative to the full list when the consumer just needs the number.
+
+    Defined before observation_detail so the literal `/observations/counter/`
+    path is matched ahead of `/observations/{stable_id}/`.
+    """
+    user = request.user if request.user.is_authenticated else None
+    qs = Observation.objects.filtered_from_my_params(
+        species_ids=filters.speciesIds,
+        datasets_ids=filters.datasetIds,
+        basis_of_record_ids=filters.basisOfRecordIds,
+        start_date=filters.startDate,
+        end_date=filters.endDate,
+        areas_ids=filters.areaIds,
+        status_for_user=filters.status,
+        initial_data_import_ids=filters.initialDataImportIds,
+        user=user,
+        verified_filter=filters.verifiedFilter,
+        area_filter_mode=filters.areaFilterMode,
+        approaching_distance_km=filters.approachingDistanceKm,
+    )
+    return {"count": qs.count()}
 
 
 @api_v2.post(

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -21,6 +21,14 @@ class SpeciesOut(Schema):
     tags: list[str]
 
 
+class SpeciesPerPolygonIn(Schema):
+    geojson: dict  # GeoJSON FeatureCollection (EPSG:4326), Polygon/MultiPolygon features
+
+
+class SpeciesPerPolygonOut(SpeciesOut):
+    observationCountInPolygon: int
+
+
 class DatasetOut(Schema):
     id: int
     gbifKey: str

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -96,6 +96,12 @@ class ObservationsPageOut(Schema):
     items: list[ObservationOut]
 
 
+class CountOut(Schema):
+    """The number of observations matching a filter set."""
+
+    count: int
+
+
 class HistogramEntryOut(Schema):
     year: int
     month: int

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -516,6 +516,28 @@ def test_page_size_at_max_is_accepted(client, observations_data):
     assert resp.status_code == 200
 
 
+def test_observations_counter_matches_list_count(client, observations_data):
+    """GET /observations/counter/ returns the same count as the full list (M7)."""
+    total = client.get(reverse("api-v2:observations_list")).json()["count"]
+    resp = client.get("/api/v2/observations/counter/")
+    assert resp.status_code == 200
+    assert resp.json() == {"count": total}
+
+
+def test_observations_counter_respects_filters(client, observations_data):
+    sp = observations_data["species"]
+    resp = client.get("/api/v2/observations/counter/", {"speciesIds": sp.pk})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+
+def test_counter_route_not_shadowed_by_detail(client, observations_data):
+    """/observations/counter/ resolves to the counter, not observation_detail('counter')."""
+    resp = client.get("/api/v2/observations/counter/")
+    assert resp.status_code == 200
+    assert "count" in resp.json()
+
+
 # --- Filter wiring ---
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -141,6 +141,48 @@ def test_species_list_empty_tags(client, filter_lists_data):
     assert entry["tags"] == []
 
 
+def test_species_per_polygon_returns_species_with_count(client, observations_data):
+    """POST /species/per-polygon/ returns species in the polygon with their count (N1)."""
+    # A FeatureCollection with a box around the fixture observation at
+    # (4.35, 50.85) in EPSG:4326 (same GeoJSON shape as areas/from-drawing).
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[4.0, 50.5], [5.0, 50.5], [5.0, 51.0], [4.0, 51.0], [4.0, 50.5]]
+                    ],
+                },
+            }
+        ],
+    }
+    resp = client.post(
+        "/api/v2/species/per-polygon/",
+        data={"geojson": geojson},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    sp = next(r for r in rows if r["id"] == observations_data["species"].pk)
+    assert sp["observationCountInPolygon"] == 1
+    assert "vernacularNameEn" in sp  # 3-lang shape (PR6a)
+    # The other species' observation has no location -> not in any polygon.
+    assert all(r["id"] != observations_data["other_species"].pk for r in rows)
+
+
+def test_species_per_polygon_invalid_geojson_returns_422(client):
+    resp = client.post(
+        "/api/v2/species/per-polygon/",
+        data={"geojson": {"type": "Nonsense"}},
+        content_type="application/json",
+    )
+    assert resp.status_code == 422
+
+
 # --- /api/v2/datasets/ ---
 
 

--- a/dashboard/tests/views/test_public_api.py
+++ b/dashboard/tests/views/test_public_api.py
@@ -971,3 +971,20 @@ def test_species_list_cors_enabled(public_api_data, client):
         reverse("dashboard:public-api:species-list-json"), {}, **request_headers
     )
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+@pytest.mark.parametrize(
+    "name, query",
+    [
+        ("species-list-json", ""),
+        ("filtered-observations-counter", ""),
+        ("filtered-observations-data-page", "?limit=10&page_number=1"),
+        ("species-per-polygon-json", "?p=POLYGON((4 50,5 50,5 51,4 51,4 50))"),
+    ],
+)
+def test_legacy_endpoints_are_deprecated(public_api_data, client, name, query):
+    """Each legacy /api JSON endpoint signals deprecation + a successor link."""
+    resp = client.get(f"{reverse(f'dashboard:public-api:{name}')}{query}")
+    assert resp.status_code == 200
+    assert resp.headers.get("Deprecation") == "true"
+    assert 'rel="successor-version"' in resp.headers.get("Link", "")

--- a/dashboard/views/deprecation.py
+++ b/dashboard/views/deprecation.py
@@ -1,0 +1,41 @@
+"""Helpers for marking legacy endpoints deprecated.
+
+The legacy public `/api/*` JSON endpoints have v2 successors under `/api/v2/`.
+We signal their deprecation per RFC 8594, but deliberately do NOT set a `Sunset`
+removal date yet: the removal timeline depends on the still-open public-API
+governance decision. Consumers get the `Deprecation` flag and a link to the
+successor so they can migrate at their own pace.
+"""
+from functools import wraps
+from typing import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+
+def deprecated_endpoint(successor: str) -> Callable:
+    """Mark a view's responses deprecated, pointing at its v2 successor.
+
+    Adds two response headers:
+    - ``Deprecation: true`` (RFC 8594)
+    - ``Link: <successor>; rel="successor-version"`` (RFC 8288)
+
+    No ``Sunset`` header is set - see the module docstring.
+
+    Parameters
+    ----------
+    successor : str
+        The path of the v2 endpoint that replaces this one, e.g.
+        ``/api/v2/observations/counter/``.
+    """
+
+    def decorator(view: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
+        @wraps(view)
+        def wrapper(request: HttpRequest, *args, **kwargs) -> HttpResponse:
+            response = view(request, *args, **kwargs)
+            response["Deprecation"] = "true"
+            response["Link"] = f'<{successor}>; rel="successor-version"'
+            return response
+
+        return wrapper
+
+    return decorator

--- a/dashboard/views/public_api.py
+++ b/dashboard/views/public_api.py
@@ -8,6 +8,7 @@ from gisserver.types import XsdElement, XsdTypes  # type: ignore
 from gisserver.views import WFSView  # type: ignore
 
 from dashboard.models import Species, DATA_SRID, Observation
+from dashboard.views.deprecation import deprecated_endpoint
 from dashboard.views.helpers import (
     model_to_json_list,
     filtered_observations_from_request,
@@ -15,6 +16,7 @@ from dashboard.views.helpers import (
 )
 
 
+@deprecated_endpoint(successor="/api/v2/observations/counter/")
 def filtered_observations_counter_json(request: HttpRequest) -> JsonResponse:
     """Count the observations according to the filters received
 
@@ -27,6 +29,7 @@ def filtered_observations_counter_json(request: HttpRequest) -> JsonResponse:
     return JsonResponse({"count": qs.count()})
 
 
+@deprecated_endpoint(successor="/api/v2/observations/")
 def filtered_observations_data_page_json(request: HttpRequest) -> JsonResponse:
     """Main endpoint to get paginated observations (data tables, ...)
 
@@ -121,6 +124,7 @@ def filtered_observations_data_page_json(request: HttpRequest) -> JsonResponse:
     )
 
 
+@deprecated_endpoint(successor="/api/v2/species/")
 def species_list_json(_) -> JsonResponse:
     """A list of all species known to the system, in JSON format
 
@@ -129,6 +133,7 @@ def species_list_json(_) -> JsonResponse:
     return model_to_json_list(Species)
 
 
+@deprecated_endpoint(successor="/api/v2/species/per-polygon/")
 def species_per_polygon_json(request: HttpRequest) -> JsonResponse:
     """An object with species details and observations counter, for each species that occurs in the given polygon
 


### PR DESCRIPTION
## Summary

PR7b - the legacy-migration half of PR7 (PR7a = v2 mark/area hygiene, #326).
Gives the remaining legacy public `/api/*` JSON endpoints clean v2 successors and
marks the legacy ones deprecated. **No SPA changes** - the SPA consumes no legacy
`/api/*` endpoint; these are external-consumer concerns.

- **M7:** `GET /api/v2/observations/counter/` - a lightweight `{count}` for a
  filter set (successor to `/api/filtered-observations/counter`). Registered
  before `observation_detail` so the literal path wins.
- **N1:** `POST /api/v2/species/per-polygon/` - replaces the WKT-in-query legacy
  endpoint with a GeoJSON FeatureCollection body; returns the 3-language species
  shape + `observationCountInPolygon`; malformed GeoJSON -> 422.
- **M4/M7/M12/N1:** the four legacy JSON endpoints now return `Deprecation: true`
  + `Link: <successor>; rel="successor-version"` via a reusable
  `@deprecated_endpoint` decorator. **No Sunset date** - the removal timeline
  depends on the still-open public-API governance decision (sub-project B). The
  WFS endpoint is untouched, and the `mode=short` polymorphism (M12) is not
  carried into v2 (use the full list or WFS).

## Test plan
- [x] Backend pytest: 427 passed (counter, per-polygon, deprecation-header tests; legacy payloads unchanged)
- [x] mypy clean
- [x] Playwright: 82 passed (no SPA change; safety confirmation)
- [x] TS types regenerated; api.ts gains the two new public endpoints only

With PR7a + PR7b, the 7-PR API v2 hygiene cleanup (sub-project A.1) is complete.
Deliberately not done: M10 (canBeMarkedUnseen, declined - server geo), the
legacy Sunset date (awaits sub-project B), and matters-of-taste T1-T6.