### PR TITLE
fix(api): name the WFS service (was 'Unnamed')

### DIFF
--- a/dashboard/tests/views/test_public_api.py
+++ b/dashboard/tests/views/test_public_api.py
@@ -158,6 +158,29 @@ def public_api_data():
     }
 
 
+def _wfs_capabilities(client) -> str:
+    base_url = reverse("dashboard:public-api:wfs-observations")
+    resp = client.get(f"{base_url}?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0")
+    assert resp.status_code == 200
+    return resp.content.decode()
+
+
+def test_wfs_capabilities_uses_site_name_in_title(client, settings):
+    """The WFS GetCapabilities title is derived from SITE_NAME (not 'Unnamed')."""
+    settings.GBIF_ALERT = {**settings.GBIF_ALERT, "SITE_NAME": "Test Portal"}
+    body = _wfs_capabilities(client)
+    assert "Unnamed" not in body
+    assert "Test Portal - observations" in body
+
+
+def test_wfs_capabilities_title_falls_back_without_site_name(client, settings):
+    """With no SITE_NAME configured, the title falls back to 'GBIF Alert'."""
+    settings.GBIF_ALERT = {**settings.GBIF_ALERT, "SITE_NAME": ""}
+    body = _wfs_capabilities(client)
+    assert "Unnamed" not in body
+    assert "GBIF Alert - observations" in body
+
+
 def test_observations_json_view_data(public_api_data, client):
     """If the user is authenticated, there is data about which observations were already seen by that user"""
     client.login(username="frusciante1", password="12345")

--- a/dashboard/views/public_api.py
+++ b/dashboard/views/public_api.py
@@ -1,9 +1,10 @@
 """Public-facing API views"""
+from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.paginator import Paginator
 from django.db.models import Count
 from django.http import JsonResponse, HttpRequest
-from gisserver.features import FeatureType, field  # type: ignore
+from gisserver.features import FeatureType, ServiceDescription, field  # type: ignore
 from gisserver.types import XsdElement, XsdTypes  # type: ignore
 from gisserver.views import WFSView  # type: ignore
 
@@ -225,6 +226,22 @@ class CustomXsdElementDataSetGBIFKey(XSDElementForceStringType):
 
 
 class ObservationsWFSView(WFSView):
+    def get_service_description(self, service: str) -> ServiceDescription:
+        # Without this, django-gisserver advertises the service as "Unnamed" in
+        # GetCapabilities. Derive the title from the deployment's SITE_NAME, with
+        # a sensible fallback when it is not configured.
+        site_name = settings.GBIF_ALERT.get("SITE_NAME") or "GBIF Alert"
+        return ServiceDescription(
+            title=f"{site_name} - observations",
+            abstract=(
+                "Species observations served as an OGC Web Feature Service (WFS), "
+                "for use in desktop GIS such as QGIS. Powered by GBIF Alert."
+            ),
+            keywords=["observations", "biodiversity", "species", "GBIF"],
+            provider_name=site_name,
+            provider_site="https://github.com/riparias/gbif-alert",
+        )
+
     feature_types = [
         FeatureType(
             Observation.objects.all(),


### PR DESCRIPTION
## Summary

The observations WFS advertised itself as **"Unnamed"** in GetCapabilities
(visible in QGIS and any WFS client). django-gisserver falls back to
`ServiceDescription(title="Unnamed")` when a `WFSView` sets no
`service_description`, and `ObservationsWFSView` never set one.

Adds a `get_service_description()` to `ObservationsWFSView` returning a
`ServiceDescription` with:
- **title** derived from the deployment's `SITE_NAME` (`"{SITE_NAME} - observations"`,
  fallback `"GBIF Alert - observations"` when unset),
- an **abstract** describing the service, and
- **keywords**.

Spotted via the new /api-docs landing page's WFS link (#328).

## Test plan
- [x] New tests: GetCapabilities title uses SITE_NAME, and falls back when unset; no "Unnamed"
- [x] Full public_api suite green (59)
- [x] mypy clean

Backend-only (no SPA / template changes).