### PR TITLE
Document implicit error responses in the v2 OpenAPI schema

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -1303,6 +1303,24 @@ export interface operations {
                     "application/json": components["schemas"]["AreaOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
             /** @description Unprocessable Entity */
             422: {
                 headers: {
@@ -1334,6 +1352,24 @@ export interface operations {
                     "application/json": components["schemas"]["GeoJSONFeatureCollectionOut"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_area_create_from_drawing: {
@@ -1356,6 +1392,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AreaOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -1386,6 +1440,33 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
             };
             /** @description Conflict */
             409: {
@@ -1420,6 +1501,33 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AreaOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -1604,6 +1712,24 @@ export interface operations {
                     "application/json": components["schemas"]["QueuedOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_observation_detail: {
@@ -1624,6 +1750,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ObservationDetailOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -1650,6 +1785,33 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CommentOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -1683,6 +1845,33 @@ export interface operations {
                     "application/json": components["schemas"]["OkOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_observation_mark_as_unseen: {
@@ -1705,8 +1894,26 @@ export interface operations {
                     "application/json": components["schemas"]["OkOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -1754,6 +1961,15 @@ export interface operations {
                     "application/json": components["schemas"]["AlertOut"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_alert_create: {
@@ -1776,6 +1992,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AlertOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -1809,6 +2043,24 @@ export interface operations {
                     "application/json": components["schemas"]["AlertOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_alert_update: {
@@ -1833,6 +2085,33 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AlertOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -1863,6 +2142,33 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
             };
         };
     };
@@ -1952,6 +2258,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
             /** @description Unprocessable Entity */
             422: {
                 headers: {
@@ -1981,6 +2305,15 @@ export interface operations {
                     "application/json": components["schemas"]["ProfileOut"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_profile_put: {
@@ -2003,6 +2336,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProfileOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -2032,6 +2383,24 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
         };
     };
     dashboard_api_v2_api_tokens_list: {
@@ -2050,6 +2419,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiTokenOut"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
         };
@@ -2074,6 +2452,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiTokenCreatedOut"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
                 };
             };
             /** @description Unprocessable Entity */
@@ -2104,6 +2500,33 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailErrorOut"];
+                };
             };
         };
     };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -145,6 +145,17 @@ api_v2_spa = NinjaAPI(
     },
 )
 
+# Implicit error responses that django-ninja produces without us returning them
+# explicitly. They all share the DetailErrorOut shape ({"detail": "..."}), the
+# same body ninja renders for auth failures, CSRF failures and not-found errors.
+# We merge these into the relevant `response=` maps (via `**ERR_401` etc.) so
+# they appear in the public OpenAPI schema. This is purely declarative: ninja
+# renders exception-driven responses through its own handlers, so adding these
+# keys does not change runtime behaviour.
+ERR_401 = {401: DetailErrorOut}  # missing or invalid credentials
+ERR_403 = {403: DetailErrorOut}  # session write without a valid CSRF token
+ERR_404 = {404: DetailErrorOut}  # object not found, or not owned by the user
+
 
 def _vernacular_names(species: Species) -> dict[str, str]:
     """The species' vernacular name in all three languages, as flat fields (N6).
@@ -229,7 +240,10 @@ def areas_list(request: HttpRequest):
     ]
 
 
-@api_v2.get("/areas/{area_id}/geojson/", response=GeoJSONFeatureCollectionOut)
+@api_v2.get(
+    "/areas/{area_id}/geojson/",
+    response={200: GeoJSONFeatureCollectionOut, **ERR_403, **ERR_404},
+)
 def area_geojson(request: HttpRequest, area_id: int):
     """Return GeoJSON (FeatureCollection, EPSG:4326) for a single area.
 
@@ -245,7 +259,7 @@ def area_geojson(request: HttpRequest, area_id: int):
 
 @api_v2.post(
     "/areas/",
-    response={201: AreaOut, 422: DetailErrorOut},
+    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_create(
@@ -280,7 +294,7 @@ def area_create(
 
 @api_v2.post(
     "/areas/from-drawing/",
-    response={201: AreaOut, 422: DetailErrorOut},
+    response={201: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_create_from_drawing(request: HttpRequest, payload: AreaFromDrawingIn):
@@ -307,7 +321,7 @@ def area_create_from_drawing(request: HttpRequest, payload: AreaFromDrawingIn):
 
 @api_v2.patch(
     "/areas/{area_id}/",
-    response={200: AreaOut, 422: DetailErrorOut},
+    response={200: AreaOut, 422: DetailErrorOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
@@ -335,7 +349,7 @@ def area_patch(request: HttpRequest, area_id: int, payload: AreaPatchIn):
 
 @api_v2.delete(
     "/areas/{area_id}/",
-    response={204: None, 409: DetailErrorOut},
+    response={204: None, 409: DetailErrorOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def area_delete(request: HttpRequest, area_id: int):
@@ -594,7 +608,7 @@ def observations_counter(request: HttpRequest, filters: Query[FiltersQuery]):
 
 @api_v2.post(
     "/observations/mark-as-seen/",
-    response={200: QueuedOut},
+    response={200: QueuedOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def observations_mark_all_as_seen(request: HttpRequest, filters: FiltersQuery):
@@ -626,7 +640,10 @@ def observations_mark_all_as_seen(request: HttpRequest, filters: FiltersQuery):
     return 200, {"queued": True, "count": count}
 
 
-@api_v2.get("/observations/{stable_id}/", response=ObservationDetailOut)
+@api_v2.get(
+    "/observations/{stable_id}/",
+    response={200: ObservationDetailOut, **ERR_404},
+)
 def observation_detail(request: HttpRequest, stable_id: str):
     try:
         obs = Observation.objects.select_related(
@@ -697,7 +714,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
 
 @api_v2.post(
     "/observations/{stable_id}/comments/",
-    response={200: CommentOut, 422: DetailErrorOut},
+    response={200: CommentOut, 422: DetailErrorOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def observation_add_comment(request: HttpRequest, stable_id: str, payload: CommentIn):
@@ -744,7 +761,7 @@ def page_fragment(request: HttpRequest, identifier: str):
 
 @api_v2.post(
     "/observations/{stable_id}/mark-as-seen/",
-    response={200: OkOut},
+    response={200: OkOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def observation_mark_as_seen(request: HttpRequest, stable_id: str):
@@ -764,7 +781,7 @@ def observation_mark_as_seen(request: HttpRequest, stable_id: str):
 
 @api_v2.post(
     "/observations/{stable_id}/mark-as-unseen/",
-    response={200: OkOut, 403: DetailErrorOut},
+    response={200: OkOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def observation_mark_as_unseen(request: HttpRequest, stable_id: str):
@@ -872,7 +889,11 @@ def alert_notification_frequencies(request: HttpRequest):
     return [{"id": k, "label": str(v)} for k, v in Alert.EMAIL_NOTIFICATION_CHOICES]
 
 
-@api_v2.get("/alerts/", response=list[AlertOut], auth=[ApiTokenAuth(), django_auth])
+@api_v2.get(
+    "/alerts/",
+    response={200: list[AlertOut], **ERR_401},
+    auth=[ApiTokenAuth(), django_auth],
+)
 def alerts_list(request: HttpRequest):
     """Return all alerts belonging to the authenticated user."""
     user = cast(User, request.user)
@@ -885,7 +906,9 @@ def alerts_list(request: HttpRequest):
 
 
 @api_v2.post(
-    "/alerts/", response={201: AlertOut, 422: ValidationErrorOut}, auth=[ApiTokenAuth(), django_auth]
+    "/alerts/",
+    response={201: AlertOut, 422: ValidationErrorOut, **ERR_401, **ERR_403},
+    auth=[ApiTokenAuth(), django_auth],
 )
 def alert_create(request: HttpRequest, payload: AlertIn):
     """Create a new alert for the authenticated user."""
@@ -896,7 +919,11 @@ def alert_create(request: HttpRequest, payload: AlertIn):
     return 201, _alert_to_out(alert)
 
 
-@api_v2.get("/alerts/{alert_id}/", response=AlertOut, auth=[ApiTokenAuth(), django_auth])
+@api_v2.get(
+    "/alerts/{alert_id}/",
+    response={200: AlertOut, **ERR_401, **ERR_404},
+    auth=[ApiTokenAuth(), django_auth],
+)
 def alert_detail(request: HttpRequest, alert_id: int):
     """Return one alert. 404 if it does not belong to the current user."""
     alert = get_object_or_404(
@@ -911,7 +938,7 @@ def alert_detail(request: HttpRequest, alert_id: int):
 
 @api_v2.put(
     "/alerts/{alert_id}/",
-    response={200: AlertOut, 422: ValidationErrorOut},
+    response={200: AlertOut, 422: ValidationErrorOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
 def alert_update(request: HttpRequest, alert_id: int, payload: AlertIn):
@@ -929,7 +956,11 @@ def alert_update(request: HttpRequest, alert_id: int, payload: AlertIn):
     return 200, _alert_to_out(alert)
 
 
-@api_v2.delete("/alerts/{alert_id}/", response={204: None}, auth=[ApiTokenAuth(), django_auth])
+@api_v2.delete(
+    "/alerts/{alert_id}/",
+    response={204: None, **ERR_401, **ERR_403, **ERR_404},
+    auth=[ApiTokenAuth(), django_auth],
+)
 def alert_delete(request: HttpRequest, alert_id: int):
     """Delete an alert. 404 if it does not belong to the current user."""
     alert = get_object_or_404(Alert, id=alert_id, user=request.user)
@@ -988,7 +1019,7 @@ def auth_signup(request: HttpRequest, payload: SignUpIn):
 
 @api_v2.post(
     "/auth/password-change/",
-    response={204: None, 422: ValidationErrorOut},
+    response={204: None, 422: ValidationErrorOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def auth_password_change(request: HttpRequest, payload: PasswordChangeIn):
@@ -1024,7 +1055,7 @@ def news_mark_visited(request: HttpRequest):
 
 @api_v2.get(
     "/profile/",
-    response=ProfileOut,
+    response={200: ProfileOut, **ERR_401},
     auth=[ApiTokenAuth(), django_auth],
 )
 def profile_get(request: HttpRequest):
@@ -1044,7 +1075,7 @@ def profile_get(request: HttpRequest):
 
 @api_v2.put(
     "/profile/",
-    response={200: ProfileOut, 422: ValidationErrorOut},
+    response={200: ProfileOut, 422: ValidationErrorOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def profile_put(request: HttpRequest, payload: ProfileIn):
@@ -1084,7 +1115,7 @@ def profile_put(request: HttpRequest, payload: ProfileIn):
 
 @api_v2.delete(
     "/account/",
-    response={204: None},
+    response={204: None, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
 def account_delete(request: HttpRequest):
@@ -1110,7 +1141,11 @@ def _api_token_to_out(token: ApiToken) -> dict:
     }
 
 
-@api_v2.get("/api-tokens/", response=list[ApiTokenOut], auth=django_auth)
+@api_v2.get(
+    "/api-tokens/",
+    response={200: list[ApiTokenOut], **ERR_401},
+    auth=django_auth,
+)
 def api_tokens_list(request: HttpRequest):
     """List the current user's API tokens (never the secret value)."""
     user = cast(User, request.user)
@@ -1119,7 +1154,7 @@ def api_tokens_list(request: HttpRequest):
 
 @api_v2.post(
     "/api-tokens/",
-    response={201: ApiTokenCreatedOut, 422: DetailErrorOut},
+    response={201: ApiTokenCreatedOut, 422: DetailErrorOut, **ERR_401, **ERR_403},
     auth=django_auth,
 )
 def api_token_create(request: HttpRequest, payload: ApiTokenCreateIn):
@@ -1132,7 +1167,11 @@ def api_token_create(request: HttpRequest, payload: ApiTokenCreateIn):
     return 201, {**_api_token_to_out(token), "token": raw}
 
 
-@api_v2.delete("/api-tokens/{token_id}/", response={204: None}, auth=django_auth)
+@api_v2.delete(
+    "/api-tokens/{token_id}/",
+    response={204: None, **ERR_401, **ERR_403, **ERR_404},
+    auth=django_auth,
+)
 def api_token_delete(request: HttpRequest, token_id: int):
     """Revoke one of the current user's tokens."""
     user = cast(User, request.user)

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -2551,3 +2551,57 @@ def test_api_token_cannot_delete_another_users_token(client, auth_data):
     resp = client.delete(f"/api/v2/api-tokens/{token.pk}/")
     assert resp.status_code == 404
     assert ApiToken.objects.filter(pk=token.pk).exists()
+
+
+# --- OpenAPI error-response completeness ---
+#
+# The view code can return implicit error responses (401 on auth failure, 403 on
+# a session write missing its CSRF token, 404 on a missing/not-owned object). We
+# declare these in each endpoint's `response=` map so the public OpenAPI schema
+# is honest about them. The runtime behaviours are exercised by the tests above;
+# these guard that the *schema* keeps advertising them. Status keys are ints, and
+# every one of these error responses uses the DetailErrorOut envelope.
+#
+# Paths are relative to the API root (no /api/v2 prefix), matching the schema.
+ERROR_RESPONSE_EXPECTATIONS = [
+    ("/areas/{area_id}/geojson/", "get", {403, 404}),
+    ("/areas/", "post", {401, 403}),
+    ("/areas/from-drawing/", "post", {401, 403}),
+    ("/areas/{area_id}/", "patch", {401, 403, 404}),
+    ("/areas/{area_id}/", "delete", {401, 403, 404}),
+    ("/observations/mark-as-seen/", "post", {401, 403}),
+    ("/observations/{stable_id}/", "get", {404}),
+    ("/observations/{stable_id}/comments/", "post", {401, 403, 404}),
+    ("/observations/{stable_id}/mark-as-seen/", "post", {401, 403, 404}),
+    ("/observations/{stable_id}/mark-as-unseen/", "post", {401, 403, 404}),
+    ("/alerts/", "get", {401}),
+    ("/alerts/", "post", {401, 403}),
+    ("/alerts/{alert_id}/", "get", {401, 404}),
+    ("/alerts/{alert_id}/", "put", {401, 403, 404}),
+    ("/alerts/{alert_id}/", "delete", {401, 403, 404}),
+    ("/auth/password-change/", "post", {401, 403}),
+    ("/profile/", "get", {401}),
+    ("/profile/", "put", {401, 403}),
+    ("/account/", "delete", {401, 403}),
+    ("/api-tokens/", "get", {401}),
+    ("/api-tokens/", "post", {401, 403}),
+    ("/api-tokens/{token_id}/", "delete", {401, 403, 404}),
+]
+
+
+@pytest.mark.parametrize("path, method, expected_codes", ERROR_RESPONSE_EXPECTATIONS)
+def test_openapi_declares_error_responses(path, method, expected_codes):
+    """Each endpoint's OpenAPI entry advertises its error responses as DetailErrorOut."""
+    from dashboard.api_v2 import api_v2
+
+    schema = api_v2.get_openapi_schema()
+    responses = schema["paths"][f"/api/v2{path}"][method]["responses"]
+    declared = set(responses.keys())
+    assert expected_codes <= declared, (
+        f"{method.upper()} {path} missing {expected_codes - declared} in OpenAPI"
+    )
+    for code in expected_codes:
+        ref = responses[code]["content"]["application/json"]["schema"]["$ref"]
+        assert ref.endswith("/DetailErrorOut"), (
+            f"{method.upper()} {path} response {code} should be DetailErrorOut, got {ref}"
+        )


### PR DESCRIPTION
## What

Makes the public v2 OpenAPI schema honest about the error responses the view code can already produce. Several endpoints return 401 (auth failure), 403 (session write without a CSRF token) or 404 (missing/not-owned object), but their `response=` maps only declared the success and semantic-error statuses, so those errors were invisible to anyone reading the schema (or generating a client from it).

This is the first slice of the deferred **A.2** API-hygiene work, triggered by an error-completeness audit of the schema.

## Approach

All three implicit responses share the same body django-ninja already renders - `{"detail": "..."}` = the existing `DetailErrorOut` schema:
- 401 -> `{"detail": "Unauthorized"}`
- 403 (CSRF) -> `{"detail": "CSRF check Failed"}`
- 404 -> `{"detail": "..."}` (from `get_object_or_404` / `HttpError(404)`)

So the change is **purely declarative** - ninja renders exception-driven responses through its own handlers, independent of the `response=` map, which only drives OpenAPI generation. Verified: full v2 suite unchanged.

### Scope (agreed)
- **401** on every login-required endpoint.
- **403 (CSRF)** on session-accepting unsafe-method writes (POST/PUT/PATCH/DELETE). GET endpoints get no CSRF. Where a semantic 403 already existed (geojson, mark-as-unseen) the same `DetailErrorOut` covers both.
- **404** on path-param lookups.
- **Out of scope:** Tier-3 broad request-validation 422 (different shape - `{detail: [...]}` - and would collide with the semantic 422s several endpoints already declare); the internal `/api/v2/spa/` instance.

## Changes

- `dashboard/api_v2.py`: add `ERR_401`/`ERR_403`/`ERR_404` constants and merge them into 22 endpoint response maps via `**ERR_xxx`.
- `dashboard/tests/views/test_api_v2.py`: parametrized `test_openapi_declares_error_responses` (22 cases) asserting each endpoint advertises its error codes as `DetailErrorOut`.
- `assets/frontend/types/api.ts`: regenerated from the updated schema (additive error-response types).

## Verification

- v2 suite: 189 passed (167 existing + 22 new).
- Full Playwright suite green (85); `api_v2.py` mypy-clean; frontend build clean.
- Runtime behaviours (geojson 403/404, invalid-token 401, CSRF 403, cross-user 404) were already covered by existing tests; this PR guards the *schema*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)