### PR TITLE
Fix stale maintainer comments pointing to non-existent files

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -454,7 +454,9 @@ class ObservationManager(models.Manager["Observation"]):
         # !! IMPORTANT !! Make sure the observation filtering here is equivalent to what's done in
         # views.maps.JINJASQL_FRAGMENT_FILTER_OBSERVATIONS. Otherwise, observations returned on the map and on other
         # components (table, ...) will be inconsistent.
-        # !! If adding new filters, make also sure they are properly documented in the docstrings of "api.py"
+        # !! If adding new filters, make sure they are documented where the API exposes them: the
+        # FiltersQuery schema in dashboard/api_v2_schemas.py (which drives the v2 OpenAPI docs) and
+        # the legacy dashboard/views/public_api.py.
         qs = self.model.objects.select_related(
             "species",
             "source_dataset",

--- a/dashboard/views/public_api.py
+++ b/dashboard/views/public_api.py
@@ -21,7 +21,7 @@ from dashboard.views.helpers import (
 def filtered_observations_counter_json(request: HttpRequest) -> JsonResponse:
     """Count the observations according to the filters received
 
-    See `internal_api.py`'s docstring for the observations filtering.
+    See dashboard/views/helpers.py (filtered_observations_from_request) for the observations filtering.
 
     parameters:
     - filters: same format than other endpoints: getting observations, map tiles, ...


### PR DESCRIPTION
## What

Two maintainer comments pointed readers to files that no longer exist (`api.py`, `internal_api.py`) - the P3 stale-comment item from the API hygiene review.

- `dashboard/models.py`: the "if adding new filters, document them in api.py" reminder now points to the real homes - the `FiltersQuery` schema in `dashboard/api_v2_schemas.py` (which drives the v2 OpenAPI docs) and the legacy `dashboard/views/public_api.py`.
- `dashboard/views/public_api.py`: "See internal_api.py's docstring" now points to `dashboard/views/helpers.py` (`filtered_observations_from_request`), where the shared observation filtering actually lives.

Comment/docstring only - no behaviour change. (The nearby `models.py` reference to `views.maps.JINJASQL_FRAGMENT_FILTER_OBSERVATIONS` was checked and is still accurate, so left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)