### PR TITLE
Clean up the v2 observation-detail payload (A.2 group A)

### DIFF
--- a/assets/frontend/components/ObservationDetailPanel.vue
+++ b/assets/frontend/components/ObservationDetailPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import Card from "primevue/card";
 import Button from "primevue/button";
@@ -34,6 +34,23 @@ const commentError = ref<string | null>(null);
 const markingUnseen = ref(false);
 
 const isAuthenticated: boolean = getNavConfig().user.isAuthenticated;
+
+// The public API no longer exposes a Django admin URL; superusers rebuild it
+// here from the observation id (the API used to leak this staff-only link).
+const adminUrl = computed(() => {
+    const nc = getNavConfig();
+    return nc.user.isSuperuser && obs.value
+        ? `${nc.urls.admin}dashboard/observation/${obs.value.id}/change/`
+        : null;
+});
+
+// initialDataImport is now a structured object; reproduce the old
+// "Data import #N (date)" label for display.
+const initialDataImportLabel = computed(() => {
+    if (!obs.value) return "";
+    const di = obs.value.initialDataImport;
+    return `${di.name} (${new Date(di.startTimestamp).toLocaleDateString(locale.value)})`;
+});
 
 async function load() {
     notFound.value = false;
@@ -141,8 +158,8 @@ onMounted(load);
                 </div>
                 <div class="detail-header-actions">
                     <a
-                        v-if="obs.adminUrl"
-                        :href="obs.adminUrl"
+                        v-if="adminUrl"
+                        :href="adminUrl"
                         class="p-button p-button-danger p-button-sm"
                     >
                         {{ t("message.showInAdmin") }}
@@ -227,7 +244,7 @@ onMounted(load);
                             </template>
 
                             <dt>{{ t("message.firstImportedDuring") }}</dt>
-                            <dd>{{ obs.initialDataImport }}</dd>
+                            <dd>{{ initialDataImportLabel }}</dd>
                         </dl>
 
                     </template>

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -882,6 +882,21 @@ export interface components {
             /** Deletedbecauseauthordeleted */
             deletedBecauseAuthorDeleted: boolean;
         };
+        /**
+         * InitialDataImportOut
+         * @description The data import that first brought an observation into the system.
+         */
+        InitialDataImportOut: {
+            /** Id */
+            id: number;
+            /** Name */
+            name: string;
+            /**
+             * Starttimestamp
+             * Format: date-time
+             */
+            startTimestamp: string;
+        };
         /** ObservationDetailOut */
         ObservationDetailOut: {
             /** Id */
@@ -932,14 +947,14 @@ export interface components {
             basisOfRecordId: number;
             /** Coordinateuncertaintyinmeters */
             coordinateUncertaintyInMeters: number | null;
-            /** Initialdataimport */
-            initialDataImport: string;
+            initialDataImport: components["schemas"]["InitialDataImportOut"];
             /** Seenbycurrentuser */
             seenByCurrentUser: boolean | null;
-            /** Canbemarkedunseen */
+            /**
+             * Canbemarkedunseen
+             * @description Per-user capability flag: true when this observation matches one of the caller's alerts and can therefore be marked unseen. False for anonymous callers and observations outside the caller's alerts.
+             */
             canBeMarkedUnseen: boolean;
-            /** Adminurl */
-            adminUrl: string | null;
             /** Comments */
             comments: components["schemas"]["CommentOut"][];
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -663,10 +663,6 @@ def observation_detail(request: HttpRequest, stable_id: str):
         # time (audit M11). GET itself no longer mutates seen state.
         can_be_marked_unseen = user.obs_match_alerts(obs)
 
-    admin_url: str | None = None
-    if request.user.is_authenticated and request.user.is_superuser:
-        admin_url = obs.get_admin_url()
-
     lon, lat = obs.lonlat_4326_tuple
 
     comments = [
@@ -704,10 +700,9 @@ def observation_detail(request: HttpRequest, stable_id: str):
         "verified": obs.verified,
         "basisOfRecordId": obs.basis_of_record_id,
         "coordinateUncertaintyInMeters": obs.coordinate_uncertainty_in_meters,
-        "initialDataImport": str(obs.initial_data_import),
+        "initialDataImport": obs.initial_data_import.as_dict,
         "seenByCurrentUser": seen_by_current_user,
         "canBeMarkedUnseen": can_be_marked_unseen,
-        "adminUrl": admin_url,
         "comments": comments,
     }
 

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -128,6 +128,14 @@ class CommentIn(Schema):
     text: str
 
 
+class InitialDataImportOut(Schema):
+    """The data import that first brought an observation into the system."""
+
+    id: int
+    name: str
+    startTimestamp: datetime.datetime
+
+
 class ObservationDetailOut(Schema):
     id: int
     stableId: str
@@ -156,10 +164,15 @@ class ObservationDetailOut(Schema):
     verified: bool
     basisOfRecordId: int
     coordinateUncertaintyInMeters: float | None
-    initialDataImport: str
+    initialDataImport: InitialDataImportOut
     seenByCurrentUser: bool | None
-    canBeMarkedUnseen: bool
-    adminUrl: str | None
+    canBeMarkedUnseen: bool = Field(
+        description=(
+            "Per-user capability flag: true when this observation matches one of "
+            "the caller's alerts and can therefore be marked unseen. False for "
+            "anonymous callers and observations outside the caller's alerts."
+        )
+    )
     comments: list[CommentOut]
 
 

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -677,12 +677,6 @@ class Observation(models.Model):
     class OtherIdenticalObservationIsNewer(Exception):
         pass
 
-    def get_admin_url(self) -> str:
-        return reverse(
-            "admin:%s_%s_change" % (self._meta.app_label, self._meta.model_name),
-            args=(self.id,),
-        )
-
     def mark_as_seen_by(self, user: WebsiteUser) -> None:
         """
         Mark the observation as "seen" by a given user.

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -1082,6 +1082,28 @@ def test_detail_field_values(client, observation_detail_data):
     assert data["date"] == "2024-05-01"
 
 
+def test_detail_initial_data_import_is_object(client, observation_detail_data):
+    """initialDataImport is a structured object, not an opaque string repr."""
+    obs = observation_detail_data["obs"]
+    di = observation_detail_data["di"]
+    data = client.get(f"/api/v2/observations/{obs.stable_id}/").json()
+    assert data["initialDataImport"] == {
+        "id": di.pk,
+        "name": f"Data import #{di.pk}",
+        "startTimestamp": "2024-01-01T00:00:00Z",
+    }
+
+
+def test_detail_omits_admin_url_even_for_superuser(client, observation_detail_data):
+    """The staff-only admin URL is no longer exposed on the public endpoint."""
+    User = get_user_model()
+    User.objects.create_superuser("super", "super@example.com", "pw")
+    client.login(username="super", password="pw")
+    obs = observation_detail_data["obs"]
+    data = client.get(f"/api/v2/observations/{obs.stable_id}/").json()
+    assert "adminUrl" not in data
+
+
 # --- canBeMarkedUnseen ---
 
 


### PR DESCRIPTION
## What

Group A of the A.2 hygiene work (see the audit in Obsidian): remove SPA/internal quirks from the public `GET /api/v2/observations/{stable_id}/` payload, while v2 adoption is still low and breaking changes are cheap.

## Changes

- **`adminUrl` removed** - it was a Django admin link, only ever populated for superusers; a staff-tooling leak in a public data API. The SPA observation panel now rebuilds the link client-side from the observation id when `navConfig.user.isSuperuser`. Also removed the now-dead `Observation.get_admin_url()` (its only caller was this field).
- **`initialDataImport` reshaped** from an opaque string repr (`"Data import #N (date)"`) to a structured `InitialDataImportOut {id, name, startTimestamp}`, consistent with the id-based modeling used elsewhere. The SPA reproduces the old "Data import #N (date)" label from the object.
- **`canBeMarkedUnseen` kept** - on reflection it is legitimate per-user capability data (like `seenByCurrentUser`: true when the observation matches one of the caller's alerts). Now documented with a `Field(description=...)` rather than removed.

## Breaking contract changes

- `adminUrl` is gone from the observation-detail response.
- `initialDataImport` is now an object, not a string.

(Acceptable now - v2 was only just announced public and external adoption is minimal; this is exactly why the audit flagged field-shape fixes as time-sensitive.)

## Tests / verification

- New: `test_detail_initial_data_import_is_object`, `test_detail_omits_admin_url_even_for_superuser`.
- v2 + model suites: 263 passed. Full Playwright suite green (85). Backend mypy clean. Frontend build clean. `api.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)