### PR TITLE
Rename seen/unseen -> viewed/notViewed on the v2 API (A.2)

### DIFF
--- a/assets/frontend/components/ActiveFilterChips.vue
+++ b/assets/frontend/components/ActiveFilterChips.vue
@@ -119,7 +119,7 @@ const chips = computed<Chip[]>(() => {
 
     // Observation status
     if (filtersStore.status !== null) {
-        const label = filtersStore.status === "unseen" ? t("message.unseen") : t("message.seen");
+        const label = filtersStore.status === "notViewed" ? t("message.unseen") : t("message.seen");
         result.push({
             kind: "text",
             key: "status",

--- a/assets/frontend/components/AlertCard.vue
+++ b/assets/frontend/components/AlertCard.vue
@@ -64,8 +64,8 @@ function confirmDelete() {
                     {{ alert.name }}
                 </span>
                 <Badge
-                    v-if="alert.unseenCount > 0"
-                    :value="alert.unseenCount"
+                    v-if="alert.notViewedCount > 0"
+                    :value="alert.notViewedCount"
                     severity="danger"
                     class="unseen-badge"
                 />

--- a/assets/frontend/components/AlertSidebar.vue
+++ b/assets/frontend/components/AlertSidebar.vue
@@ -43,7 +43,7 @@ function confirmMarkAllAsViewed() {
         acceptLabel: t("message.yesImSure"),
         rejectLabel: t("message.cancel"),
         accept: async () => {
-            const resp = await fetch("/api/v2/observations/mark-as-seen/", {
+            const resp = await fetch("/api/v2/observations/mark-as-viewed/", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -175,7 +175,7 @@ const formattedDatasetsCount = computed(() =>
                 <label>{{ t("message.observationStatus") }}</label>
                 <ObservationStatusToggle />
                 <Button
-                    v-if="alert.unseenCount > 0 && filtersStore.status !== 'seen'"
+                    v-if="alert.notViewedCount > 0 && filtersStore.status !== 'viewed'"
                     :label="t('message.markAllAsViewed')"
                     icon="pi pi-check"
                     size="small"

--- a/assets/frontend/components/ObservationDetailPanel.vue
+++ b/assets/frontend/components/ObservationDetailPanel.vue
@@ -71,7 +71,7 @@ async function load() {
             // The detail GET no longer marks the observation as seen (the API is
             // side-effect free); do it explicitly so the table/sidebar reflect it
             // when the drawer closes. Best-effort: seen state isn't load-critical.
-            await fetch(`/api/v2/observations/${props.stableId}/mark-as-seen/`, {
+            await fetch(`/api/v2/observations/${props.stableId}/mark-as-viewed/`, {
                 method: "POST",
                 headers: { "X-CSRFToken": getCsrf() },
             }).catch(() => { /* non-fatal */ });
@@ -106,7 +106,7 @@ async function submitComment() {
 async function markUnseen() {
     markingUnseen.value = true;
     try {
-        const resp = await fetch(`/api/v2/observations/${props.stableId}/mark-as-unseen/`, {
+        const resp = await fetch(`/api/v2/observations/${props.stableId}/mark-as-not-viewed/`, {
             method: "POST",
             headers: { "X-CSRFToken": getCsrf() },
         });
@@ -168,7 +168,7 @@ onMounted(load);
             </div>
 
             <!-- Mark unseen -->
-            <div v-if="obs.canBeMarkedUnseen" class="mark-unseen-row">
+            <div v-if="obs.canBeMarkedNotViewed" class="mark-unseen-row">
                 <Button
                     severity="warn"
                     size="small"

--- a/assets/frontend/components/ObservationStatusToggle.vue
+++ b/assets/frontend/components/ObservationStatusToggle.vue
@@ -9,15 +9,15 @@ const filtersStore = useFiltersStore();
 
 const statusOptions = [
     { value: "all", label: t("message.all") },
-    { value: "seen", label: t("message.seen") },
-    { value: "unseen", label: t("message.unseen") },
+    { value: "viewed", label: t("message.seen") },
+    { value: "notViewed", label: t("message.unseen") },
 ];
 
 // SelectButton requires non-null values, so we map null <-> "all" at the boundary.
 const selectedStatus = computed({
     get: () => filtersStore.status ?? "all",
     set: (val: string) => {
-        filtersStore.status = val === "all" ? null : (val as "seen" | "unseen");
+        filtersStore.status = val === "all" ? null : (val as "viewed" | "notViewed");
     },
 });
 </script>

--- a/assets/frontend/components/ObservationsView.vue
+++ b/assets/frontend/components/ObservationsView.vue
@@ -111,7 +111,7 @@ const columnPopover = ref();
 // --- Observation fetching ---
 
 const observations = ref<ObservationOut[]>([]);
-const hasSeen = computed(() => observations.value.some((o) => o.seenByCurrentUser !== null));
+const hasSeen = computed(() => observations.value.some((o) => o.viewedByCurrentUser !== null));
 const totalRecords = ref(0);
 const loading = ref(false);
 const currentPage = ref(1);
@@ -205,7 +205,7 @@ onMounted(async () => {
     await loadObservations();
     // props.unseenFallback is evaluated once at mount; the fallback is first-load-only
     // behaviour, not something that re-runs when filters change.
-    if (props.unseenFallback && totalRecords.value === 0 && filtersStore.status === "unseen") {
+    if (props.unseenFallback && totalRecords.value === 0 && filtersStore.status === "notViewed") {
         filtersStore.status = null;
         reloadOnFilterChange.cancel();
         await loadObservations();
@@ -327,8 +327,8 @@ onMounted(async () => {
                         </Column>
                         <Column v-if="visibleColumns.has('seen') && hasSeen" :header="t('message.seen')">
                             <template #body="{ data }">
-                                <span v-if="data.seenByCurrentUser === true">&#10003;</span>
-                                <span v-else-if="data.seenByCurrentUser === false">&bull;</span>
+                                <span v-if="data.viewedByCurrentUser === true">&#10003;</span>
+                                <span v-else-if="data.viewedByCurrentUser === false">&bull;</span>
                             </template>
                         </Column>
                     </DataTable>

--- a/assets/frontend/composables/useFilterSync.ts
+++ b/assets/frontend/composables/useFilterSync.ts
@@ -42,15 +42,15 @@ function buildQuery(
     if (store.startDate) q.startDate = store.startDate;
     if (store.endDate) q.endDate = store.endDate;
     if (isAuthenticated) {
-        // For auth users "unseen" is the default - omit it for a clean URL.
+        // For auth users "notViewed" is the default - omit it for a clean URL.
         // null means "all" - write explicitly so the user can bookmark/share it.
         if (store.status === null) q.status = "all";
-        else if (store.status === "seen") q.status = "seen";
+        else if (store.status === "viewed") q.status = "viewed";
     } else {
         // For anonymous users null (all) is the default - omit it.
-        // Explicit "seen" or "unseen" choices are written to the URL.
-        if (store.status === "seen") q.status = "seen";
-        else if (store.status === "unseen") q.status = "unseen";
+        // Explicit "viewed" or "notViewed" choices are written to the URL.
+        if (store.status === "viewed") q.status = "viewed";
+        else if (store.status === "notViewed") q.status = "notViewed";
     }
     if (store.verifiedFilter !== "all") q.verifiedFilter = store.verifiedFilter;
     if (store.areaFilterMode !== "inside") q.areaFilterMode = store.areaFilterMode;
@@ -96,14 +96,22 @@ export function useFilterSync(isAuthenticated: boolean = true): void {
             store.initialDataImportIds = getIntArray(query, "initialDataImportIds");
             store.startDate = getString(query, "startDate");
             store.endDate = getString(query, "endDate");
-            // Auth users: "unseen" is the default (no param); "all" in the URL means null.
-            // Anonymous users: null (all) is the default (no param); "unseen" must be explicit.
+            // Auth users: "notViewed" is the default (no param); "all" in the URL means null.
+            // Anonymous users: null (all) is the default (no param); "notViewed" must be explicit.
             if (isAuthenticated) {
                 store.status =
-                    status === "seen" ? "seen" : status === "all" ? null : "unseen";
+                    status === "viewed"
+                        ? "viewed"
+                        : status === "all"
+                          ? null
+                          : "notViewed";
             } else {
                 store.status =
-                    status === "seen" ? "seen" : status === "unseen" ? "unseen" : null;
+                    status === "viewed"
+                        ? "viewed"
+                        : status === "notViewed"
+                          ? "notViewed"
+                          : null;
             }
             store.verifiedFilter =
                 verified === "verified" || verified === "unverified" ? verified : "all";

--- a/assets/frontend/pages/AlertDetailPage.vue
+++ b/assets/frontend/pages/AlertDetailPage.vue
@@ -55,14 +55,14 @@ onMounted(async () => {
             approachingDistanceKm: alert.value.approachingDistanceKm,
             startDate: null,
             endDate: null,
-            status: "unseen",
+            status: "notViewed",
         });
     } finally {
         alertLoading.value = false;
     }
 });
 
-// Re-fetch the alert (for unseenCount, which gates the sidebar bulk action)
+// Re-fetch the alert (for notViewedCount, which gates the sidebar bulk action)
 // whenever a consumer reports an observation status change.
 watch(() => resultsStore.statusEpoch, fetchAlert);
 

--- a/assets/frontend/stores/filters.ts
+++ b/assets/frontend/stores/filters.ts
@@ -11,7 +11,7 @@ export const useFiltersStore = defineStore("filters", () => {
     const startDate = ref<string | null>(null);
     const endDate = ref<string | null>(null);
 
-    const status = ref<"seen" | "unseen" | null>(null);
+    const status = ref<"viewed" | "notViewed" | null>(null);
     const verifiedFilter = ref<"all" | "verified" | "unverified">("all");
 
     const areaFilterMode = ref<"inside" | "approaching" | "both">("inside");

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -264,7 +264,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/observations/mark-as-seen/": {
+    "/api/v2/observations/mark-as-viewed/": {
         parameters: {
             query?: never;
             header?: never;
@@ -322,7 +322,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/observations/{stable_id}/mark-as-seen/": {
+    "/api/v2/observations/{stable_id}/mark-as-viewed/": {
         parameters: {
             query?: never;
             header?: never;
@@ -345,7 +345,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/observations/{stable_id}/mark-as-unseen/": {
+    "/api/v2/observations/{stable_id}/mark-as-not-viewed/": {
         parameters: {
             query?: never;
             header?: never;
@@ -822,8 +822,8 @@ export interface components {
             identificationVerificationStatus: string;
             /** Basisofrecordid */
             basisOfRecordId: number;
-            /** Seenbycurrentuser */
-            seenByCurrentUser?: boolean | null;
+            /** Viewedbycurrentuser */
+            viewedByCurrentUser?: boolean | null;
         };
         /** ObservationsPageOut */
         ObservationsPageOut: {
@@ -948,13 +948,13 @@ export interface components {
             /** Coordinateuncertaintyinmeters */
             coordinateUncertaintyInMeters: number | null;
             initialDataImport: components["schemas"]["InitialDataImportOut"];
-            /** Seenbycurrentuser */
-            seenByCurrentUser: boolean | null;
+            /** Viewedbycurrentuser */
+            viewedByCurrentUser: boolean | null;
             /**
-             * Canbemarkedunseen
-             * @description Per-user capability flag: true when this observation matches one of the caller's alerts and can therefore be marked unseen. False for anonymous callers and observations outside the caller's alerts.
+             * Canbemarkednotviewed
+             * @description Per-user capability flag: true when this observation matches one of the caller's alerts and can therefore be marked not viewed. False for anonymous callers and observations outside the caller's alerts.
              */
-            canBeMarkedUnseen: boolean;
+            canBeMarkedNotViewed: boolean;
             /** Comments */
             comments: components["schemas"]["CommentOut"][];
         };
@@ -1000,8 +1000,8 @@ export interface components {
             areaFilterMode: string;
             /** Approachingdistancekm */
             approachingDistanceKm: number | null;
-            /** Unseencount */
-            unseenCount: number;
+            /** Notviewedcount */
+            notViewedCount: number;
             /** Speciesdetails */
             speciesDetails: components["schemas"]["AlertSpeciesOut"][];
             /** Lastemailsentat */

--- a/assets/frontend/utils/filterParams.ts
+++ b/assets/frontend/utils/filterParams.ts
@@ -6,7 +6,7 @@ type FiltersQuery = components["schemas"]["FiltersQuery"];
 
 /**
  * Serialize the current filters store into URLSearchParams suitable for the
- * api/v2 observation endpoints (list, histogram, mark-as-seen).
+ * api/v2 observation endpoints (list, histogram, mark-as-viewed).
  *
  * Callers add their own extras (page, pageSize, orderBy, etc.) onto the
  * returned object.
@@ -45,7 +45,7 @@ export function filtersToParams(
 /**
  * Serialize the filters store into a FiltersQuery JSON body, for the mutating
  * POST endpoints that take their filters in the request body (e.g. bulk
- * mark-as-seen - audit N4).
+ * mark-as-viewed - audit N4).
  */
 export function filtersToBody(filtersStore: FiltersStore): FiltersQuery {
     return {

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -156,6 +156,15 @@ ERR_401 = {401: DetailErrorOut}  # missing or invalid credentials
 ERR_403 = {403: DetailErrorOut}  # session write without a valid CSRF token
 ERR_404 = {404: DetailErrorOut}  # object not found, or not owned by the user
 
+# The public API speaks "viewed"/"notViewed"; the internal observation filtering
+# still uses "seen"/"unseen". Map the consumer-facing status value to the internal
+# one at the API boundary. Unknown/None values mean "no status filter".
+_API_STATUS_TO_INTERNAL = {"viewed": "seen", "notViewed": "unseen"}
+
+
+def _internal_status(api_status: str | None) -> str | None:
+    return _API_STATUS_TO_INTERNAL.get(api_status) if api_status else None
+
 
 def _vernacular_names(species: Species) -> dict[str, str]:
     """The species' vernacular name in all three languages, as flat fields (N6).
@@ -469,7 +478,7 @@ def observations_list(
         start_date=filters.startDate,
         end_date=filters.endDate,
         areas_ids=filters.areaIds,
-        status_for_user=filters.status,
+        status_for_user=_internal_status(filters.status),
         initial_data_import_ids=filters.initialDataImportIds,
         user=user,
         verified_filter=filters.verifiedFilter,
@@ -533,7 +542,7 @@ def observations_list(
             "verified": obs.verified,
             "identificationVerificationStatus": obs.identification_verification_status,
             "basisOfRecordId": obs.basis_of_record_id,
-            "seenByCurrentUser": (obs.pk not in unseen_ids)
+            "viewedByCurrentUser": (obs.pk not in unseen_ids)
             if user is not None
             else None,
         }
@@ -559,7 +568,7 @@ def observations_histogram(request: HttpRequest, filters: Query[FiltersQuery]):
         start_date=filters.startDate,
         end_date=filters.endDate,
         areas_ids=filters.areaIds,
-        status_for_user=filters.status,
+        status_for_user=_internal_status(filters.status),
         initial_data_import_ids=filters.initialDataImportIds,
         user=user,
         verified_filter=filters.verifiedFilter,
@@ -596,7 +605,7 @@ def observations_counter(request: HttpRequest, filters: Query[FiltersQuery]):
         start_date=filters.startDate,
         end_date=filters.endDate,
         areas_ids=filters.areaIds,
-        status_for_user=filters.status,
+        status_for_user=_internal_status(filters.status),
         initial_data_import_ids=filters.initialDataImportIds,
         user=user,
         verified_filter=filters.verifiedFilter,
@@ -607,7 +616,7 @@ def observations_counter(request: HttpRequest, filters: Query[FiltersQuery]):
 
 
 @api_v2.post(
-    "/observations/mark-as-seen/",
+    "/observations/mark-as-viewed/",
     response={200: QueuedOut, **ERR_401, **ERR_403},
     auth=[ApiTokenAuth(), django_auth],
 )
@@ -626,7 +635,7 @@ def observations_mark_all_as_seen(request: HttpRequest, filters: FiltersQuery):
         start_date=filters.startDate,
         end_date=filters.endDate,
         areas_ids=filters.areaIds,
-        status_for_user=filters.status,
+        status_for_user=_internal_status(filters.status),
         initial_data_import_ids=filters.initialDataImportIds,
         user=user,
         verified_filter=filters.verifiedFilter,
@@ -658,7 +667,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
     can_be_marked_unseen = False
     if user is not None:
         seen_by_current_user = obs.already_seen_by(user)
-        # canBeMarkedUnseen is a capability flag: the drawer marks the obs seen
+        # canBeMarkedNotViewed is a capability flag: the drawer marks the obs seen
         # on open, so it no longer depends on the obs already being seen at GET
         # time (audit M11). GET itself no longer mutates seen state.
         can_be_marked_unseen = user.obs_match_alerts(obs)
@@ -701,8 +710,8 @@ def observation_detail(request: HttpRequest, stable_id: str):
         "basisOfRecordId": obs.basis_of_record_id,
         "coordinateUncertaintyInMeters": obs.coordinate_uncertainty_in_meters,
         "initialDataImport": obs.initial_data_import.as_dict,
-        "seenByCurrentUser": seen_by_current_user,
-        "canBeMarkedUnseen": can_be_marked_unseen,
+        "viewedByCurrentUser": seen_by_current_user,
+        "canBeMarkedNotViewed": can_be_marked_unseen,
         "comments": comments,
     }
 
@@ -755,7 +764,7 @@ def page_fragment(request: HttpRequest, identifier: str):
 
 
 @api_v2.post(
-    "/observations/{stable_id}/mark-as-seen/",
+    "/observations/{stable_id}/mark-as-viewed/",
     response={200: OkOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
@@ -775,7 +784,7 @@ def observation_mark_as_seen(request: HttpRequest, stable_id: str):
 
 
 @api_v2.post(
-    "/observations/{stable_id}/mark-as-unseen/",
+    "/observations/{stable_id}/mark-as-not-viewed/",
     response={200: OkOut, **ERR_401, **ERR_403, **ERR_404},
     auth=[ApiTokenAuth(), django_auth],
 )
@@ -807,7 +816,7 @@ def _alert_to_out(alert: Alert) -> dict:
         "verifiedFilter": alert.verified_filter,
         "areaFilterMode": alert.area_filter_mode,
         "approachingDistanceKm": alert.approaching_distance_km,
-        "unseenCount": alert.unseen_observations().count(),
+        "notViewedCount": alert.unseen_observations().count(),
         "speciesDetails": [
             {"scientificName": s.name, **_vernacular_names(s)}
             for s in alert.species.all()

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -65,7 +65,7 @@ class FiltersQuery(Schema):
     startDate: datetime.date | None = None
     endDate: datetime.date | None = None
     areaIds: list[int] = Field(default_factory=list)
-    status: str | None = None
+    status: str | None = None  # API values: "viewed" / "notViewed" (mapped to internal seen/unseen)
     initialDataImportIds: list[int] = Field(default_factory=list)
     verifiedFilter: str = "all"
     areaFilterMode: str = "inside"
@@ -94,7 +94,7 @@ class ObservationOut(Schema):
     verified: bool
     identificationVerificationStatus: str  # empty string when not provided by GBIF
     basisOfRecordId: int
-    seenByCurrentUser: bool | None = None
+    viewedByCurrentUser: bool | None = None
 
 
 class ObservationsPageOut(Schema):
@@ -165,11 +165,11 @@ class ObservationDetailOut(Schema):
     basisOfRecordId: int
     coordinateUncertaintyInMeters: float | None
     initialDataImport: InitialDataImportOut
-    seenByCurrentUser: bool | None
-    canBeMarkedUnseen: bool = Field(
+    viewedByCurrentUser: bool | None
+    canBeMarkedNotViewed: bool = Field(
         description=(
             "Per-user capability flag: true when this observation matches one of "
-            "the caller's alerts and can therefore be marked unseen. False for "
+            "the caller's alerts and can therefore be marked not viewed. False for "
             "anonymous callers and observations outside the caller's alerts."
         )
     )
@@ -211,7 +211,7 @@ class AlertOut(Schema):
     verifiedFilter: str
     areaFilterMode: str
     approachingDistanceKm: float | None
-    unseenCount: int
+    notViewedCount: int
     speciesDetails: list[AlertSpeciesOut]
     lastEmailSentAt: datetime.datetime | None
 

--- a/dashboard/tests/playwright/test_alerts.py
+++ b/dashboard/tests/playwright/test_alerts.py
@@ -380,7 +380,7 @@ def test_alert_detail_mark_all_button_hidden_when_no_unseen(page: Page, live_ser
     user = User.objects.create_user(username="u13", password="pass", email="u13@t.com")
     sp = _make_species("Procambarus fallax", 8879526)
     alert = _make_alert(user, "Alert without unseen", sp)
-    # No matching unseen observation created -> unseenCount == 0.
+    # No matching unseen observation created -> notViewedCount == 0.
 
     login(page, live_server.url, "u13", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
@@ -392,7 +392,7 @@ def test_alert_detail_mark_all_button_hidden_when_no_unseen(page: Page, live_ser
 @pytest.mark.django_db(transaction=True)
 def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server):
     """Opening then closing the drawer drops the now-seen observation from the
-    status=unseen view and hides the bulk button (unseenCount becomes 0)."""
+    status=notViewed view and hides the bulk button (notViewedCount becomes 0)."""
     User = get_user_model()
     user = User.objects.create_user(username="u14", password="pass", email="u14@t.com")
     sp = _make_species("Procambarus fallax", 8879526)
@@ -430,7 +430,7 @@ def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server)
     page.get_by_role("cell", name=re.compile("Procambarus fallax", re.I)).first.click()
     # Wait for the drawer to actually open and its detail content to render before
     # closing. networkidle alone is unreliable here: the page is already idle from
-    # load, so it resolves before the drawer fires its detail GET + mark-as-seen
+    # load, so it resolves before the drawer fires its detail GET + mark-as-viewed
     # POST, and an immediate Escape would race (and cancel) those requests.
     drawer = page.locator('[data-pc-name="drawer"]')
     expect(drawer).to_be_visible()
@@ -441,6 +441,6 @@ def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server)
     page.keyboard.press("Escape")
     page.wait_for_load_state("networkidle")
 
-    # The (now-seen) observation no longer matches the status=unseen filter:
-    # the row is gone and the bulk button disappears (unseenCount == 0).
+    # The (now-seen) observation no longer matches the status=notViewed filter:
+    # the row is gone and the bulk button disappears (notViewedCount == 0).
     expect(page.get_by_role("button", name="Mark all as viewed")).to_have_count(0)

--- a/dashboard/tests/playwright/test_index_page.py
+++ b/dashboard/tests/playwright/test_index_page.py
@@ -335,7 +335,7 @@ def test_filter_state_preserved_when_drawer_closed(page: Page, live_server):
 def test_authenticated_user_sees_unseen_by_default(page: Page, live_server):
     """An authenticated user with unseen observations sees only those by default.
 
-    The Pinia filters store initialises status='unseen'. If the user has unseen
+    The Pinia filters store initialises status='notViewed'. If the user has unseen
     observations the smart-default code does not override it, so only the unseen
     subset is shown.
     """
@@ -362,7 +362,7 @@ def test_authenticated_user_sees_unseen_by_default(page: Page, live_server):
 @pytest.mark.django_db(transaction=True)
 def test_smart_status_default_falls_back_to_all(page: Page, live_server):
     """When an authenticated user has no unseen observations the status filter
-    falls back silently from 'unseen' to 'all', showing all observations.
+    falls back silently from 'notViewed' to 'all', showing all observations.
 
     The smart-default logic in IndexPage.vue detects 0 results with the initial
     'unseen' filter and re-fetches with status=null (all) so the user is never
@@ -389,7 +389,7 @@ def test_anonymous_user_sees_no_unseen_filter_badge(page: Page, live_server):
     """An anonymous user visiting the index page must not see an 'Unseen' active
     filter badge.
 
-    Before the fix, the Pinia store initialised status='unseen' unconditionally,
+    Before the fix, the Pinia store initialised status='notViewed' unconditionally,
     so the ActiveFilterChips component would show an 'Unseen' badge for every
     visitor regardless of whether they were logged in - which makes no sense for
     anonymous users who have no seen/unseen tracking at all.
@@ -407,9 +407,9 @@ def test_anonymous_user_sees_no_unseen_filter_badge(page: Page, live_server):
 
 @pytest.mark.django_db(transaction=True)
 def test_anonymous_user_sees_all_observations_by_default(page: Page, live_server):
-    """An anonymous user on the index page sees all observations, not just 'unseen'.
+    """An anonymous user on the index page sees all observations, not just 'notViewed'.
 
-    The default status filter for anonymous users must be null (all), not 'unseen'.
+    The default status filter for anonymous users must be null (all), not 'notViewed'.
     """
     basis = BasisOfRecord.objects.create(name="HUMAN_OBSERVATION")
     sp = Species.objects.create(name="Procambarus fallax", gbif_taxon_key=8879526)

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -472,15 +472,15 @@ def test_observations_list_null_location(client, observations_data):
     assert item["lon"] is None
 
 
-# --- seenByCurrentUser ---
+# --- viewedByCurrentUser ---
 
 
 def test_seen_by_current_user_is_null_for_anonymous(client, observations_data):
-    """Anonymous users get null for seenByCurrentUser."""
+    """Anonymous users get null for viewedByCurrentUser."""
     obs = observations_data["obs"]
     response = client.get(reverse("api-v2:observations_list"))
     item = next(i for i in response.json()["items"] if i["id"] == obs.pk)
-    assert item["seenByCurrentUser"] is None
+    assert item["viewedByCurrentUser"] is None
 
 
 def test_seen_by_current_user_true_when_no_unseen_record(client, observations_data):
@@ -489,7 +489,7 @@ def test_seen_by_current_user_true_when_no_unseen_record(client, observations_da
     client.login(username="obs_user", password="12345")
     response = client.get(reverse("api-v2:observations_list"))
     item = next(i for i in response.json()["items"] if i["id"] == obs.pk)
-    assert item["seenByCurrentUser"]
+    assert item["viewedByCurrentUser"]
 
 
 def test_seen_by_current_user_false_when_unseen_record_exists(
@@ -502,7 +502,22 @@ def test_seen_by_current_user_false_when_unseen_record_exists(
     client.login(username="obs_user", password="12345")
     response = client.get(reverse("api-v2:observations_list"))
     item = next(i for i in response.json()["items"] if i["id"] == obs.pk)
-    assert not item["seenByCurrentUser"]
+    assert not item["viewedByCurrentUser"]
+
+
+def test_status_filter_uses_viewed_vocabulary(client, observations_data):
+    """The status filter accepts viewed/notViewed (mapped to internal seen/unseen)."""
+    obs = observations_data["obs"]
+    user = observations_data["user"]
+    ObservationUnseen.objects.create(observation=obs, user=user)  # obs is now "not viewed"
+    client.login(username="obs_user", password="12345")
+    url = reverse("api-v2:observations_list")
+
+    not_viewed = {i["id"] for i in client.get(url, {"status": "notViewed"}).json()["items"]}
+    assert obs.pk in not_viewed
+
+    viewed = {i["id"] for i in client.get(url, {"status": "viewed"}).json()["items"]}
+    assert obs.pk not in viewed
 
 
 # --- Pagination ---
@@ -1064,8 +1079,8 @@ def test_detail_camel_case_keys(client, observation_detail_data):
         "datasetGbifKey",
         "date",
         "basisOfRecordId",
-        "seenByCurrentUser",
-        "canBeMarkedUnseen",
+        "viewedByCurrentUser",
+        "canBeMarkedNotViewed",
         "comments",
     ):
         assert key in data, f"Missing key: {key}"
@@ -1104,13 +1119,13 @@ def test_detail_omits_admin_url_even_for_superuser(client, observation_detail_da
     assert "adminUrl" not in data
 
 
-# --- canBeMarkedUnseen ---
+# --- canBeMarkedNotViewed ---
 
 
 def test_can_be_marked_unseen_false_for_anonymous(client, observation_detail_data):
     obs = observation_detail_data["obs"]
     response = client.get(f"/api/v2/observations/{obs.stable_id}/")
-    assert not response.json()["canBeMarkedUnseen"]
+    assert not response.json()["canBeMarkedNotViewed"]
 
 
 def test_can_be_marked_unseen_false_when_no_matching_alert(
@@ -1121,7 +1136,7 @@ def test_can_be_marked_unseen_false_when_no_matching_alert(
     user = observation_detail_data["user"]
     client.force_login(user)
     response = client.get(f"/api/v2/observations/{obs.stable_id}/")
-    assert not response.json()["canBeMarkedUnseen"]
+    assert not response.json()["canBeMarkedNotViewed"]
 
 
 def test_can_be_marked_unseen_true_when_alert_matches(client, observation_detail_data):
@@ -1134,7 +1149,7 @@ def test_can_be_marked_unseen_true_when_alert_matches(client, observation_detail
     )
     alert.species.add(obs.species)
     response = client.get(f"/api/v2/observations/{obs.stable_id}/")
-    assert response.json()["canBeMarkedUnseen"]
+    assert response.json()["canBeMarkedNotViewed"]
 
 
 # --- comments ---
@@ -1188,7 +1203,7 @@ def test_add_comment_empty_text_returns_422(client, observation_detail_data):
 def test_observation_mark_unseen_anonymous_returns_401(client, observation_detail_data):
     """Anonymous users get 401 from mark-unseen, not 403."""
     obs = observation_detail_data["obs"]
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-unseen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-not-viewed/")
     assert resp.status_code == 401
 
 
@@ -1199,11 +1214,11 @@ def test_observation_mark_unseen_no_matching_alert_returns_403(
     user = observation_detail_data["user"]
     obs = observation_detail_data["obs"]
     client.force_login(user)
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-unseen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-not-viewed/")
     assert resp.status_code == 403
 
 
-# --- M11: GET side-effect removal + single mark-as-seen ---
+# --- M11: GET side-effect removal + single mark-as-viewed ---
 
 
 def test_get_detail_does_not_mark_as_seen(client, observation_detail_data):
@@ -1216,12 +1231,12 @@ def test_get_detail_does_not_mark_as_seen(client, observation_detail_data):
     assert resp.status_code == 200
     # The unseen marker is still there - the GET did not mark it seen.
     assert ObservationUnseen.objects.filter(observation=obs, user=user).exists()
-    assert resp.json()["seenByCurrentUser"] is False
+    assert resp.json()["viewedByCurrentUser"] is False
 
 
 def test_mark_as_seen_single_anonymous_returns_401(client, observation_detail_data):
     obs = observation_detail_data["obs"]
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-seen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/")
     assert resp.status_code == 401
 
 
@@ -1230,7 +1245,7 @@ def test_mark_as_seen_single_marks_observation_seen(client, observation_detail_d
     user = observation_detail_data["user"]
     ObservationUnseen.objects.create(observation=obs, user=user)
     client.force_login(user)
-    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-seen/")
+    resp = client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
     assert not ObservationUnseen.objects.filter(observation=obs, user=user).exists()
@@ -1241,7 +1256,7 @@ def test_mark_as_seen_single_unknown_stable_id_returns_404(
 ):
     user = observation_detail_data["user"]
     client.force_login(user)
-    resp = client.post("/api/v2/observations/does-not-exist/mark-as-seen/")
+    resp = client.post("/api/v2/observations/does-not-exist/mark-as-viewed/")
     assert resp.status_code == 404
 
 
@@ -1383,7 +1398,7 @@ def test_alerts_list_returns_own_alerts(client, alert_data):
     assert len(data) == 1
     assert data[0]["name"] == "My alert #1"
     assert "speciesIds" in data[0]
-    assert "unseenCount" in data[0]
+    assert "notViewedCount" in data[0]
     # N10: timestamp follows the createdAt/*Timestamp convention.
     assert "lastEmailSentAt" in data[0]
     assert "lastEmailSentOn" not in data[0]
@@ -2125,13 +2140,13 @@ def test_delete_account_success(client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/v2/observations/mark-as-seen/ (bulk mark)
+# POST /api/v2/observations/mark-as-viewed/ (bulk mark)
 # ---------------------------------------------------------------------------
 
 
 def test_mark_all_as_seen_anonymous_returns_401(client, observations_data):
     """Anonymous users may not bulk-mark observations."""
-    resp = client.post("/api/v2/observations/mark-as-seen/")
+    resp = client.post("/api/v2/observations/mark-as-viewed/")
     assert resp.status_code == 401
 
 
@@ -2151,7 +2166,7 @@ def test_mark_all_as_seen_authenticated_returns_queued(
     user = observations_data["user"]
     client.force_login(user)
     resp = client.post(
-        "/api/v2/observations/mark-as-seen/", data={}, content_type="application/json"
+        "/api/v2/observations/mark-as-viewed/", data={}, content_type="application/json"
     )
 
     assert resp.status_code == 200
@@ -2174,7 +2189,7 @@ def test_mark_all_as_seen_returns_count_of_unseen(client, observations_data, mon
         ObservationUnseen.objects.create(observation=o, user=user)
     client.force_login(user)
     resp = client.post(
-        "/api/v2/observations/mark-as-seen/",
+        "/api/v2/observations/mark-as-viewed/",
         data={"status": "all"},
         content_type="application/json",
     )
@@ -2202,7 +2217,7 @@ def test_mark_all_as_seen_respects_species_filter(
 
     client.force_login(user)
     resp = client.post(
-        "/api/v2/observations/mark-as-seen/",
+        "/api/v2/observations/mark-as-viewed/",
         data={"speciesIds": [species.pk]},
         content_type="application/json",
     )
@@ -2439,7 +2454,7 @@ def test_token_write_works_without_csrf(observation_detail_data):
     _, raw = ApiToken.create_for(user, "test")
     csrf_client = Client(enforce_csrf_checks=True)
     resp = csrf_client.post(
-        f"/api/v2/observations/{obs.stable_id}/mark-as-seen/",
+        f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/",
         HTTP_AUTHORIZATION=f"Bearer {raw}",
     )
     assert resp.status_code == 200
@@ -2454,7 +2469,7 @@ def test_session_write_still_requires_csrf(observation_detail_data):
     obs = observation_detail_data["obs"]
     csrf_client = Client(enforce_csrf_checks=True)
     csrf_client.force_login(user)
-    resp = csrf_client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-seen/")
+    resp = csrf_client.post(f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/")
     assert resp.status_code == 403
 
 
@@ -2462,7 +2477,7 @@ def test_invalid_token_returns_401(client, observation_detail_data):
     """A present-but-invalid bearer token returns 401, not a confusing CSRF 403."""
     obs = observation_detail_data["obs"]
     resp = client.post(
-        f"/api/v2/observations/{obs.stable_id}/mark-as-seen/",
+        f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/",
         HTTP_AUTHORIZATION="Bearer not-a-real-token",
     )
     assert resp.status_code == 401
@@ -2489,7 +2504,7 @@ def test_token_last_used_at_is_updated(client, observation_detail_data):
     token, raw = ApiToken.create_for(user, "t")
     assert token.last_used_at is None
     client.post(
-        f"/api/v2/observations/{obs.stable_id}/mark-as-seen/",
+        f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/",
         HTTP_AUTHORIZATION=f"Bearer {raw}",
     )
     token.refresh_from_db()
@@ -2558,7 +2573,7 @@ def test_api_token_delete_revokes(client, observation_detail_data):
     assert resp.status_code == 204
     # The revoked token no longer authenticates.
     after = client.post(
-        f"/api/v2/observations/{obs.stable_id}/mark-as-seen/",
+        f"/api/v2/observations/{obs.stable_id}/mark-as-viewed/",
         HTTP_AUTHORIZATION=f"Bearer {raw}",
     )
     assert after.status_code == 401
@@ -2591,11 +2606,11 @@ ERROR_RESPONSE_EXPECTATIONS = [
     ("/areas/from-drawing/", "post", {401, 403}),
     ("/areas/{area_id}/", "patch", {401, 403, 404}),
     ("/areas/{area_id}/", "delete", {401, 403, 404}),
-    ("/observations/mark-as-seen/", "post", {401, 403}),
+    ("/observations/mark-as-viewed/", "post", {401, 403}),
     ("/observations/{stable_id}/", "get", {404}),
     ("/observations/{stable_id}/comments/", "post", {401, 403, 404}),
-    ("/observations/{stable_id}/mark-as-seen/", "post", {401, 403, 404}),
-    ("/observations/{stable_id}/mark-as-unseen/", "post", {401, 403, 404}),
+    ("/observations/{stable_id}/mark-as-viewed/", "post", {401, 403, 404}),
+    ("/observations/{stable_id}/mark-as-not-viewed/", "post", {401, 403, 404}),
     ("/alerts/", "get", {401}),
     ("/alerts/", "post", {401, 403}),
     ("/alerts/{alert_id}/", "get", {401, 404}),


### PR DESCRIPTION
## What

Adopt a consumer-facing **"viewed"** vocabulary across the public v2 API, while keeping the Python internals (variables, model methods, querysets, the `ObservationUnseen` model) on **"seen/unseen"**. The API layer maps between the two. Done now, while v2 adoption is low and breaking changes are cheap.

A precursor to Group B - the `status` field's `Literal` will use the new `viewed`/`notViewed` tokens.

## Breaking contract changes (v2 only)

Legacy `/api/*` and WFS are deliberately **untouched** (deprecated/frozen).

- **Response fields:** `seenByCurrentUser` -> `viewedByCurrentUser`; `canBeMarkedUnseen` -> `canBeMarkedNotViewed`; `unseenCount` -> `notViewedCount`.
- **`status` filter values:** `seen`/`unseen` -> `viewed`/`notViewed` (mapped to internal `seen`/`unseen` via a small `_internal_status` helper at the API boundary).
- **Endpoint URLs:** `/observations/mark-as-seen/` -> `/mark-as-viewed/`; `/observations/{id}/mark-as-seen/` -> `/mark-as-viewed/`; `/observations/{id}/mark-as-unseen/` -> `/mark-as-not-viewed/`.

## Frontend (lockstep, same PR)

The SPA hits the same endpoints, so it changes together: field reads, the 3 fetch URLs, and the status vocabulary end-to-end (filters store, URL sync incl. browser-URL params, status toggle, filter chips). Left intentionally on "seen": user-facing **display labels** (`message.seen`/`unseen`) and the internal table **column key** `"seen"` - neither is part of the API contract. `api.ts` regenerated.

## Tests / verification

- Updated v2 + Playwright references; added `test_status_filter_uses_viewed_vocabulary` covering the boundary mapping.
- v2 suite 191 passed; full Playwright suite green (85); backend mypy clean; frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)