### PR TITLE
Type closed-choice v2 fields as Literal enums (A.2 group B)

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -768,19 +768,21 @@ export interface components {
             /** Areaids */
             areaIds?: number[];
             /** Status */
-            status?: string | null;
+            status?: ("all" | "viewed" | "notViewed") | null;
             /** Initialdataimportids */
             initialDataImportIds?: number[];
             /**
              * Verifiedfilter
              * @default all
+             * @enum {string}
              */
-            verifiedFilter: string;
+            verifiedFilter: "all" | "verified" | "unverified";
             /**
              * Areafiltermode
              * @default inside
+             * @enum {string}
              */
-            areaFilterMode: string;
+            areaFilterMode: "inside" | "approaching" | "both";
             /** Approachingdistancekm */
             approachingDistanceKm?: number | null;
         };
@@ -973,8 +975,11 @@ export interface components {
         };
         /** AlertNotificationFrequencyOut */
         AlertNotificationFrequencyOut: {
-            /** Id */
-            id: string;
+            /**
+             * Id
+             * @enum {string}
+             */
+            id: "N" | "D" | "W" | "M";
             /** Label */
             label: string;
         };
@@ -992,12 +997,21 @@ export interface components {
             basisOfRecordIds: number[];
             /** Areaids */
             areaIds: number[];
-            /** Emailnotificationsfrequency */
-            emailNotificationsFrequency: string;
-            /** Verifiedfilter */
-            verifiedFilter: string;
-            /** Areafiltermode */
-            areaFilterMode: string;
+            /**
+             * Emailnotificationsfrequency
+             * @enum {string}
+             */
+            emailNotificationsFrequency: "N" | "D" | "W" | "M";
+            /**
+             * Verifiedfilter
+             * @enum {string}
+             */
+            verifiedFilter: "all" | "verified" | "unverified";
+            /**
+             * Areafiltermode
+             * @enum {string}
+             */
+            areaFilterMode: "inside" | "approaching" | "both";
             /** Approachingdistancekm */
             approachingDistanceKm: number | null;
             /** Notviewedcount */
@@ -1050,18 +1064,21 @@ export interface components {
             /**
              * Emailnotificationsfrequency
              * @default W
+             * @enum {string}
              */
-            emailNotificationsFrequency: string;
+            emailNotificationsFrequency: "N" | "D" | "W" | "M";
             /**
              * Verifiedfilter
              * @default all
+             * @enum {string}
              */
-            verifiedFilter: string;
+            verifiedFilter: "all" | "verified" | "unverified";
             /**
              * Areafiltermode
              * @default inside
+             * @enum {string}
              */
-            areaFilterMode: string;
+            areaFilterMode: "inside" | "approaching" | "both";
             /** Approachingdistancekm */
             approachingDistanceKm?: number | null;
         };
@@ -1093,7 +1110,10 @@ export interface components {
             lastName: string;
             /** Email */
             email: string;
-            /** Language */
+            /**
+             * Language
+             * @description A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl).
+             */
             language: string;
             /** Password1 */
             password1: string;
@@ -1119,12 +1139,18 @@ export interface components {
             lastName: string;
             /** Email */
             email: string;
-            /** Language */
+            /**
+             * Language
+             * @description A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl).
+             */
             language: string;
             /** Delayvalue */
             delayValue: number;
-            /** Delayunit */
-            delayUnit: string;
+            /**
+             * Delayunit
+             * @enum {string}
+             */
+            delayUnit: "days" | "weeks" | "months" | "years";
         };
         /** ProfileIn */
         ProfileIn: {
@@ -1134,11 +1160,17 @@ export interface components {
             lastName: string;
             /** Email */
             email: string;
-            /** Language */
+            /**
+             * Language
+             * @description A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl).
+             */
             language: string;
             /** Delayvalue */
             delayValue: number;
-            /** Delayunit */
+            /**
+             * Delayunit
+             * @description One of: days, weeks, months, years.
+             */
             delayUnit: string;
         };
         /**
@@ -1605,10 +1637,10 @@ export interface operations {
                 startDate?: string | null;
                 endDate?: string | null;
                 areaIds?: number[];
-                status?: string | null;
+                status?: ("all" | "viewed" | "notViewed") | null;
                 initialDataImportIds?: number[];
-                verifiedFilter?: string;
-                areaFilterMode?: string;
+                verifiedFilter?: "all" | "verified" | "unverified";
+                areaFilterMode?: "inside" | "approaching" | "both";
                 approachingDistanceKm?: number | null;
                 page?: number;
                 pageSize?: number;
@@ -1650,10 +1682,10 @@ export interface operations {
                 startDate?: string | null;
                 endDate?: string | null;
                 areaIds?: number[];
-                status?: string | null;
+                status?: ("all" | "viewed" | "notViewed") | null;
                 initialDataImportIds?: number[];
-                verifiedFilter?: string;
-                areaFilterMode?: string;
+                verifiedFilter?: "all" | "verified" | "unverified";
+                areaFilterMode?: "inside" | "approaching" | "both";
                 approachingDistanceKm?: number | null;
             };
             header?: never;
@@ -1682,10 +1714,10 @@ export interface operations {
                 startDate?: string | null;
                 endDate?: string | null;
                 areaIds?: number[];
-                status?: string | null;
+                status?: ("all" | "viewed" | "notViewed") | null;
                 initialDataImportIds?: number[];
-                verifiedFilter?: string;
-                areaFilterMode?: string;
+                verifiedFilter?: "all" | "verified" | "unverified";
+                areaFilterMode?: "inside" | "approaching" | "both";
                 approachingDistanceKm?: number | null;
             };
             header?: never;

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -1,7 +1,22 @@
 import datetime
+from typing import Literal
 
 from ninja import Schema
 from pydantic import Field
+
+# Closed-choice value sets, exposed as enums in the OpenAPI schema (and validated
+# by ninja on input). Keep in sync with the corresponding model constants
+# (dashboard.models.Alert.* etc.). `language` is intentionally NOT a Literal: it
+# comes from settings.LANGUAGES, which is configurable per instance.
+VerifiedFilter = Literal["all", "verified", "unverified"]
+AreaFilterMode = Literal["inside", "approaching", "both"]
+EmailNotificationFrequency = Literal["N", "D", "W", "M"]
+ObservationStatus = Literal["all", "viewed", "notViewed"]  # "all" / absent = no filter
+DelayUnit = Literal["days", "weeks", "months", "years"]
+
+# `language` is not a fixed enum (instance-configurable via settings.LANGUAGES),
+# so it stays a plain string with a description rather than a Literal.
+_LANGUAGE_DESC = "A language code enabled on this site (see settings.LANGUAGES, e.g. en/fr/nl)."
 
 
 class SpeciesOut(Schema):
@@ -65,10 +80,10 @@ class FiltersQuery(Schema):
     startDate: datetime.date | None = None
     endDate: datetime.date | None = None
     areaIds: list[int] = Field(default_factory=list)
-    status: str | None = None  # API values: "viewed" / "notViewed" (mapped to internal seen/unseen)
+    status: ObservationStatus | None = None  # mapped to internal seen/unseen
     initialDataImportIds: list[int] = Field(default_factory=list)
-    verifiedFilter: str = "all"
-    areaFilterMode: str = "inside"
+    verifiedFilter: VerifiedFilter = "all"
+    areaFilterMode: AreaFilterMode = "inside"
     approachingDistanceKm: float | None = None
 
 
@@ -177,7 +192,7 @@ class ObservationDetailOut(Schema):
 
 
 class AlertNotificationFrequencyOut(Schema):
-    id: str
+    id: EmailNotificationFrequency
     label: str
 
 
@@ -187,9 +202,9 @@ class AlertIn(Schema):
     datasetIds: list[int] = Field(default_factory=list)
     basisOfRecordIds: list[int] = Field(default_factory=list)
     areaIds: list[int] = Field(default_factory=list)
-    emailNotificationsFrequency: str = "W"
-    verifiedFilter: str = "all"
-    areaFilterMode: str = "inside"
+    emailNotificationsFrequency: EmailNotificationFrequency = "W"
+    verifiedFilter: VerifiedFilter = "all"
+    areaFilterMode: AreaFilterMode = "inside"
     approachingDistanceKm: float | None = None
 
 
@@ -207,9 +222,9 @@ class AlertOut(Schema):
     datasetIds: list[int]
     basisOfRecordIds: list[int]
     areaIds: list[int]
-    emailNotificationsFrequency: str
-    verifiedFilter: str
-    areaFilterMode: str
+    emailNotificationsFrequency: EmailNotificationFrequency
+    verifiedFilter: VerifiedFilter
+    areaFilterMode: AreaFilterMode
     approachingDistanceKm: float | None
     notViewedCount: int
     speciesDetails: list[AlertSpeciesOut]
@@ -240,7 +255,7 @@ class SignUpIn(Schema):
     firstName: str = ""
     lastName: str = ""
     email: str
-    language: str
+    language: str = Field(description=_LANGUAGE_DESC)
     password1: str
     password2: str
 
@@ -256,18 +271,21 @@ class ProfileOut(Schema):
     firstName: str
     lastName: str
     email: str
-    language: str
+    language: str = Field(description=_LANGUAGE_DESC)
     delayValue: int
-    delayUnit: str
+    delayUnit: DelayUnit
 
 
 class ProfileIn(Schema):
     firstName: str
     lastName: str
     email: str
-    language: str
+    language: str = Field(description=_LANGUAGE_DESC)
     delayValue: int
-    delayUnit: str
+    # Kept as a plain string (not DelayUnit) so the view's own validation runs and
+    # returns the curated ValidationErrorOut shape; a Literal would pre-empt it
+    # with ninja's generic 422. Allowed values match DelayUnit.
+    delayUnit: str = Field(description="One of: days, weeks, months, years.")
 
 
 class DetailErrorOut(Schema):

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -520,6 +520,15 @@ def test_status_filter_uses_viewed_vocabulary(client, observations_data):
     assert obs.pk not in viewed
 
 
+def test_invalid_enum_filter_values_are_rejected(client, observations_data):
+    """Closed-choice filters are now Literal-typed, so junk values are rejected."""
+    url = reverse("api-v2:observations_list")
+    assert client.get(url, {"status": "bogus"}).status_code == 422
+    assert client.get(url, {"verifiedFilter": "bogus"}).status_code == 422
+    # A valid value still works.
+    assert client.get(url, {"verifiedFilter": "verified"}).status_code == 200
+
+
 # --- Pagination ---
 
 


### PR DESCRIPTION
## What

Group B of the A.2 hygiene work: the fixed choice-set fields were typed as bare `str`, so the OpenAPI schema gave consumers no way to learn their allowed values. Type them as `Literal` aliases - the schema now advertises real enums and ninja validates inputs (invalid values return 422).

Builds on #337 (the `viewed`/`notViewed` rename), so `status` uses the new tokens.

## Changes

- New aliases in `api_v2_schemas.py`: `VerifiedFilter`, `AreaFilterMode`, `EmailNotificationFrequency`, `ObservationStatus`, `DelayUnit`.
- Applied to `FiltersQuery`, `AlertIn`, `AlertOut`, `AlertNotificationFrequencyOut.id`, and `ProfileOut.delayUnit`.
- `status` is `Literal["all", "viewed", "notViewed"]` - `"all"`/absent both mean "no filter" (`"all"` is preserved because the bulk mark endpoint accepts it).
- **`ProfileIn.delayUnit` stays a documented `str`**: that endpoint has its own validation returning the curated `ValidationErrorOut` (per-field errors), which a `Literal` would pre-empt with ninja's generic 422 - contradicting its declared `422: ValidationErrorOut`. `ProfileOut.delayUnit` uses the `Literal` (output enum, no validation conflict).
- **`language` stays a documented `str`**: it comes from `settings.LANGUAGES` and is configurable per instance, so a hardcoded `Literal` would be wrong for other deployments.
- Regenerated `api.ts`.

## Breaking-ness

Mildly breaking: inputs with invalid enum values now return 422 (via ninja's existing request-validation, same mechanism that already rejects bad types). The SPA already used matching literal unions, so no frontend changes were needed.

## Tests / verification

- New `test_invalid_enum_filter_values_are_rejected`.
- v2 suite 193 passed; full Playwright green (85); mypy + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)