### PR TITLE
Consistency fixes on the v2 API shapes (A.2 group C)

### DIFF
--- a/assets/frontend/components/DatasetFilterModal.vue
+++ b/assets/frontend/components/DatasetFilterModal.vue
@@ -118,12 +118,12 @@ function onUnselectAll() {
             <Column :header="t('message.gbifDatasetKey')">
                 <template #body="{ data }">
                     <a
-                        v-if="data.gbifKey"
-                        :href="`https://www.gbif.org/dataset/${data.gbifKey}`"
+                        v-if="data.gbifDatasetKey"
+                        :href="`https://www.gbif.org/dataset/${data.gbifDatasetKey}`"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="gbif-link"
-                    >{{ data.gbifKey }}</a>
+                    >{{ data.gbifDatasetKey }}</a>
                 </template>
             </Column>
         </DataTable>

--- a/assets/frontend/components/ObservationDetailPanel.vue
+++ b/assets/frontend/components/ObservationDetailPanel.vue
@@ -49,7 +49,7 @@ const adminUrl = computed(() => {
 const initialDataImportLabel = computed(() => {
     if (!obs.value) return "";
     const di = obs.value.initialDataImport;
-    return `${di.name} (${new Date(di.startTimestamp).toLocaleDateString(locale.value)})`;
+    return `${di.name} (${new Date(di.startedAt).toLocaleDateString(locale.value)})`;
 });
 
 async function load() {
@@ -206,7 +206,7 @@ onMounted(load);
 
                             <dt>{{ t("message.sourceDataset") }}</dt>
                             <dd>
-                                <a :href="gbifDatasetUrl(obs.datasetGbifKey)" target="_blank">
+                                <a :href="gbifDatasetUrl(obs.gbifDatasetKey)" target="_blank">
                                     {{ obs.datasetName }}
                                 </a>
                             </dd>

--- a/assets/frontend/pages/AboutDataPage.vue
+++ b/assets/frontend/pages/AboutDataPage.vue
@@ -7,8 +7,8 @@ import ProgressSpinner from "primevue/progressspinner";
 interface DataImport {
     id: number;
     name: string;
-    startTimestamp: string;
-    endTimestamp: string | null;
+    startedAt: string;
+    endedAt: string | null;
     importedCount: number;
     newObservationsCount: number;
     skippedCount: number;
@@ -72,9 +72,9 @@ function gbifDownloadUrl(downloadId: string): string {
                 <dl style="display: grid; grid-template-columns: max-content 1fr; gap: 0.25rem 1.5rem; margin: 0;">
                     <dt style="font-weight: 600;">{{ t("message.dateTimeRange") }}</dt>
                     <dd style="margin: 0;">
-                        {{ formatDateTime(imports[0].startTimestamp) }}
-                        <template v-if="imports[0].endTimestamp">
-                            &ndash; {{ formatDateTime(imports[0].endTimestamp) }}
+                        {{ formatDateTime(imports[0].startedAt) }}
+                        <template v-if="imports[0].endedAt">
+                            &ndash; {{ formatDateTime(imports[0].endedAt) }}
                         </template>
                     </dd>
 
@@ -106,7 +106,7 @@ function gbifDownloadUrl(downloadId: string): string {
                         style="padding: 0.5rem 0.75rem; border: 1px solid var(--p-surface-200); border-radius: 6px;"
                     >
                         <strong>{{ imp.name }}</strong>
-                        &ndash; {{ formatDateTime(imp.startTimestamp) }}
+                        &ndash; {{ formatDateTime(imp.startedAt) }}
                         &ndash; {{ t("message.importedObservations") }}: {{ imp.importedCount.toLocaleString(locale) }}
                     </li>
                 </ul>

--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -652,8 +652,8 @@ export interface components {
         DatasetOut: {
             /** Id */
             id: number;
-            /** Gbifkey */
-            gbifKey: string;
+            /** Gbifdatasetkey */
+            gbifDatasetKey: string;
             /** Name */
             name: string;
         };
@@ -738,12 +738,12 @@ export interface components {
             /** Name */
             name: string;
             /**
-             * Starttimestamp
+             * Startedat
              * Format: date-time
              */
-            startTimestamp: string;
-            /** Endtimestamp */
-            endTimestamp: string | null;
+            startedAt: string;
+            /** Endedat */
+            endedAt: string | null;
             /** Importedcount */
             importedCount: number;
             /** Newobservationscount */
@@ -824,6 +824,8 @@ export interface components {
             identificationVerificationStatus: string;
             /** Basisofrecordid */
             basisOfRecordId: number;
+            /** Basisofrecordname */
+            basisOfRecordName: string;
             /** Viewedbycurrentuser */
             viewedByCurrentUser?: boolean | null;
         };
@@ -894,10 +896,10 @@ export interface components {
             /** Name */
             name: string;
             /**
-             * Starttimestamp
+             * Startedat
              * Format: date-time
              */
-            startTimestamp: string;
+            startedAt: string;
         };
         /** ObservationDetailOut */
         ObservationDetailOut: {
@@ -924,8 +926,8 @@ export interface components {
             vernacularNameFr: string;
             /** Datasetname */
             datasetName: string;
-            /** Datasetgbifkey */
-            datasetGbifKey: string;
+            /** Gbifdatasetkey */
+            gbifDatasetKey: string;
             /**
              * Date
              * Format: date
@@ -947,6 +949,8 @@ export interface components {
             verified: boolean;
             /** Basisofrecordid */
             basisOfRecordId: number;
+            /** Basisofrecordname */
+            basisOfRecordName: string;
             /** Coordinateuncertaintyinmeters */
             coordinateUncertaintyInMeters: number | null;
             initialDataImport: components["schemas"]["InitialDataImportOut"];

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -231,7 +231,7 @@ def species_per_polygon(request: HttpRequest, payload: SpeciesPerPolygonIn):
 @api_v2.get("/datasets/", response=list[DatasetOut])
 def datasets_list(request: HttpRequest):
     return [
-        {"id": d.pk, "gbifKey": d.gbif_dataset_key, "name": d.name}
+        {"id": d.pk, "gbifDatasetKey": d.gbif_dataset_key, "name": d.name}
         for d in Dataset.objects.all()
     ]
 
@@ -395,8 +395,8 @@ def data_imports_list(request: HttpRequest):
         {
             "id": di.pk,
             "name": f"Data import #{di.pk}",
-            "startTimestamp": di.start,
-            "endTimestamp": di.end,
+            "startedAt": di.start,
+            "endedAt": di.end,
             "importedCount": di.imported_observations_counter,
             "newObservationsCount": di.new_observations_count,
             "skippedCount": di.skipped_observations_counter,
@@ -542,6 +542,7 @@ def observations_list(
             "verified": obs.verified,
             "identificationVerificationStatus": obs.identification_verification_status,
             "basisOfRecordId": obs.basis_of_record_id,
+            "basisOfRecordName": obs.basis_of_record.name,
             "viewedByCurrentUser": (obs.pk not in unseen_ids)
             if user is not None
             else None,
@@ -698,7 +699,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
         "scientificName": obs.species.name,
         **_vernacular_names(obs.species),
         "datasetName": obs.source_dataset.name,
-        "datasetGbifKey": obs.source_dataset.gbif_dataset_key,
+        "gbifDatasetKey": obs.source_dataset.gbif_dataset_key,
         "date": obs.date,
         "individualCount": obs.individual_count,
         "locality": obs.locality,
@@ -708,6 +709,7 @@ def observation_detail(request: HttpRequest, stable_id: str):
         "identificationVerificationStatus": obs.identification_verification_status,
         "verified": obs.verified,
         "basisOfRecordId": obs.basis_of_record_id,
+        "basisOfRecordName": obs.basis_of_record.name,
         "coordinateUncertaintyInMeters": obs.coordinate_uncertainty_in_meters,
         "initialDataImport": obs.initial_data_import.as_dict,
         "viewedByCurrentUser": seen_by_current_user,

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -46,7 +46,7 @@ class SpeciesPerPolygonOut(SpeciesOut):
 
 class DatasetOut(Schema):
     id: int
-    gbifKey: str
+    gbifDatasetKey: str
     name: str
 
 
@@ -65,8 +65,8 @@ class BasisOfRecordOut(Schema):
 class DataImportOut(Schema):
     id: int
     name: str
-    startTimestamp: datetime.datetime
-    endTimestamp: datetime.datetime | None
+    startedAt: datetime.datetime
+    endedAt: datetime.datetime | None
     importedCount: int
     newObservationsCount: int
     skippedCount: int
@@ -109,6 +109,7 @@ class ObservationOut(Schema):
     verified: bool
     identificationVerificationStatus: str  # empty string when not provided by GBIF
     basisOfRecordId: int
+    basisOfRecordName: str
     viewedByCurrentUser: bool | None = None
 
 
@@ -148,7 +149,7 @@ class InitialDataImportOut(Schema):
 
     id: int
     name: str
-    startTimestamp: datetime.datetime
+    startedAt: datetime.datetime
 
 
 class ObservationDetailOut(Schema):
@@ -168,7 +169,7 @@ class ObservationDetailOut(Schema):
     vernacularNameNl: str
     vernacularNameFr: str
     datasetName: str
-    datasetGbifKey: str
+    gbifDatasetKey: str
     date: datetime.date
     individualCount: int | None
     locality: str
@@ -178,6 +179,7 @@ class ObservationDetailOut(Schema):
     identificationVerificationStatus: str  # empty string when not provided by GBIF
     verified: bool
     basisOfRecordId: int
+    basisOfRecordName: str
     coordinateUncertaintyInMeters: float | None
     initialDataImport: InitialDataImportOut
     viewedByCurrentUser: bool | None

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -239,7 +239,7 @@ class DataImport(models.Model):
         return {  # To be consumed on the frontend: we use JS naming conventions
             "id": self.pk,
             "name": f"Data import #{self.pk}",
-            "startTimestamp": self.start,
+            "startedAt": self.start,
         }
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -193,12 +193,12 @@ def test_datasets_list_status(client):
 
 
 def test_datasets_list_gbif_key_resolver(client, filter_lists_data):
-    """gbifKey must be taken from Dataset.gbif_dataset_key, not a non-existent field."""
+    """gbifDatasetKey must be taken from Dataset.gbif_dataset_key, not a non-existent field."""
     dataset = filter_lists_data["dataset"]
     response = client.get(reverse("api-v2:datasets_list"))
     entry = next(d for d in response.json() if d["id"] == dataset.pk)
 
-    assert entry["gbifKey"] == "4fa7b334-ce0d-4e88-aaae-2e0c138d049e"
+    assert entry["gbifDatasetKey"] == "4fa7b334-ce0d-4e88-aaae-2e0c138d049e"
     assert entry["name"] == "Test dataset"
 
 
@@ -278,11 +278,11 @@ def test_data_imports_list_computed_name(client, filter_lists_data):
 
 
 def test_data_imports_list_start_timestamp(client, filter_lists_data):
-    """startTimestamp is present and formatted as an ISO datetime string."""
+    """startedAt is present and formatted as an ISO datetime string."""
     di = filter_lists_data["di"]
     response = client.get(reverse("api-v2:data_imports_list"))
     entry = next(d for d in response.json() if d["id"] == di.pk)
-    assert entry["startTimestamp"] == "2024-03-15T10:00:00Z"
+    assert entry["startedAt"] == "2024-03-15T10:00:00Z"
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +422,7 @@ def test_observations_list_camel_case_keys(client, observations_data):
         "verified",
         "identificationVerificationStatus",
         "basisOfRecordId",
+        "basisOfRecordName",
     ):
         assert key in item, f"Missing key: {key}"
 
@@ -434,17 +435,20 @@ def test_observations_list_new_fields(client, observations_data):
     assert item["municipality"] == ""
     assert item["verified"] is False
     assert item["identificationVerificationStatus"] == ""
-    # N7: basis-of-record is an id joining to /basis-of-record/, not a label.
+    # basis-of-record is exposed as both an id (joins to /basis-of-record/) and a
+    # denormalized name, consistent with datasetName.
     assert item["basisOfRecordId"] == observations_data["basis_of_record"].pk
+    assert item["basisOfRecordName"] == observations_data["basis_of_record"].name
     assert "basisOfRecord" not in item
 
 
-def test_observation_detail_basis_of_record_is_id(client, observation_detail_data):
-    """ObservationDetailOut returns basisOfRecordId, not a label string (N7)."""
+def test_observation_detail_basis_of_record_id_and_name(client, observation_detail_data):
+    """ObservationDetailOut returns both basisOfRecordId and basisOfRecordName."""
     obs = observation_detail_data["obs"]
     bor = observation_detail_data["basis_of_record"]
     data = client.get(f"/api/v2/observations/{obs.stable_id}/").json()
     assert data["basisOfRecordId"] == bor.pk
+    assert data["basisOfRecordName"] == bor.name
     assert "basisOfRecord" not in data
 
 
@@ -1085,9 +1089,10 @@ def test_detail_camel_case_keys(client, observation_detail_data):
         "vernacularNameNl",
         "vernacularNameFr",
         "datasetName",
-        "datasetGbifKey",
+        "gbifDatasetKey",
         "date",
         "basisOfRecordId",
+        "basisOfRecordName",
         "viewedByCurrentUser",
         "canBeMarkedNotViewed",
         "comments",
@@ -1114,7 +1119,7 @@ def test_detail_initial_data_import_is_object(client, observation_detail_data):
     assert data["initialDataImport"] == {
         "id": di.pk,
         "name": f"Data import #{di.pk}",
-        "startTimestamp": "2024-01-01T00:00:00Z",
+        "startedAt": "2024-01-01T00:00:00Z",
     }
 
 


### PR DESCRIPTION
## What

Group C of the A.2 hygiene work - the consistency batch. Three breaking-ish shape fixes, done while v2 adoption is low.

## Changes

1. **basis-of-record name** (additive, non-breaking): `ObservationOut` and `ObservationDetailOut` now include `basisOfRecordName` alongside `basisOfRecordId`, matching the denormalized `datasetName` convenience. The list/detail querysets already `select_related("basis_of_record")`, so no extra queries.
2. **dataset GBIF key naming** (breaking): standardized to `gbifDatasetKey` everywhere - `DatasetOut` (was `gbifKey`) and `ObservationDetailOut` (was `datasetGbifKey`). Parallels `SpeciesOut.gbifTaxonKey` and matches the model field `gbif_dataset_key`.
3. **datetime suffixes** (breaking): `DataImport` timestamps normalized to the `...At` convention used everywhere else (`createdAt`, `lastUsedAt`): `startTimestamp` -> `startedAt`, `endTimestamp` -> `endedAt`, on `DataImportOut`, `InitialDataImportOut`, and `DataImport.as_dict` (which is v2-only - legacy uses `Species`/`Observation`).

## Frontend (lockstep)

DatasetFilterModal, ObservationDetailPanel, and AboutDataPage updated; `api.ts` regenerated. `basisOfRecordName` is additive, so the SPA keeps its existing client-side name lookup (still needed for alerts, which only carry ids).

## Tests / verification

- Renamed references; `test_observation_detail_basis_of_record_is_id` -> `..._id_and_name` (asserts both id and name); added `basisOfRecordName` to key lists and value checks.
- v2 suite 193 passed; full Playwright green (85); mypy + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)