### PR TITLE
Echo pagination metadata in the observations list response (A.2)

### DIFF
--- a/assets/frontend/types/api.ts
+++ b/assets/frontend/types/api.ts
@@ -837,6 +837,16 @@ export interface components {
             speciesCount: number;
             /** Datasetscount */
             datasetsCount: number;
+            /** Page */
+            page: number;
+            /** Pagesize */
+            pageSize: number;
+            /** Totalpages */
+            totalPages: number;
+            /** Hasnextpage */
+            hasNextPage: boolean;
+            /** Haspreviouspage */
+            hasPreviousPage: boolean;
             /** Items */
             items: components["schemas"]["ObservationOut"][];
         };

--- a/dashboard/api_v2.py
+++ b/dashboard/api_v2.py
@@ -550,10 +550,16 @@ def observations_list(
         for obs in obs_page
     ]
 
+    total_pages = (total + pageSize - 1) // pageSize  # 0 when there are no results
     return 200, {
         "count": total,
         "speciesCount": aggregates["species_count"],
         "datasetsCount": aggregates["datasets_count"],
+        "page": page,
+        "pageSize": pageSize,
+        "totalPages": total_pages,
+        "hasNextPage": page < total_pages,
+        "hasPreviousPage": page > 1,
         "items": items,
     }
 

--- a/dashboard/api_v2_schemas.py
+++ b/dashboard/api_v2_schemas.py
@@ -114,9 +114,14 @@ class ObservationOut(Schema):
 
 
 class ObservationsPageOut(Schema):
-    count: int
+    count: int  # total matching observations across all pages
     speciesCount: int
     datasetsCount: int
+    page: int
+    pageSize: int
+    totalPages: int
+    hasNextPage: bool
+    hasPreviousPage: bool
     items: list[ObservationOut]
 
 

--- a/dashboard/tests/views/test_api_v2.py
+++ b/dashboard/tests/views/test_api_v2.py
@@ -565,6 +565,30 @@ def test_pagination_second_page(client, observations_data):
     assert id_p1 != id_p2
 
 
+def test_pagination_metadata(client, observations_data):
+    """The response echoes page/pageSize/totalPages and has-next/previous flags."""
+    # 2 observations, pageSize 1 -> 2 pages.
+    p1 = client.get(reverse("api-v2:observations_list"), {"pageSize": 1, "page": 1}).json()
+    assert (p1["page"], p1["pageSize"], p1["totalPages"]) == (1, 1, 2)
+    assert p1["hasNextPage"] is True
+    assert p1["hasPreviousPage"] is False
+
+    p2 = client.get(reverse("api-v2:observations_list"), {"pageSize": 1, "page": 2}).json()
+    assert (p2["page"], p2["totalPages"]) == (2, 2)
+    assert p2["hasNextPage"] is False
+    assert p2["hasPreviousPage"] is True
+
+
+def test_pagination_metadata_no_results(client, observations_data):
+    """With no matches, totalPages is 0 and there is no next page."""
+    data = client.get(
+        reverse("api-v2:observations_list"), {"speciesIds": 999999}
+    ).json()
+    assert data["count"] == 0
+    assert data["totalPages"] == 0
+    assert data["hasNextPage"] is False
+
+
 def test_page_size_over_max_returns_400(client, observations_data):
     resp = client.get(reverse("api-v2:observations_list"), {"pageSize": 101})
     assert resp.status_code == 400


### PR DESCRIPTION
## What

The one Group D item with real consumer value (the rest are cosmetic). `ObservationsPageOut` returned the total `count` and `items` but no information about the current page position, forcing consumers to track paging blind.

Adds, all **additive / non-breaking**:
- `page` - the current page (echoed)
- `pageSize` - the page size in effect
- `totalPages` - `ceil(count / pageSize)`, `0` when there are no results
- `hasNextPage` / `hasPreviousPage` - convenience booleans

`count` is unchanged (still the grand total across pages).

## Frontend

None needed - the SPA tracks its own paging and reads `count`. `api.ts` regenerated (additive fields).

## Tests / verification

- New `test_pagination_metadata` (multi-page) and `test_pagination_metadata_no_results`.
- v2 pagination/shape tests pass; full Playwright green (85, after confirming an unrelated navbar red-dot flake passes deterministically in isolation); mypy + build clean.

## Note

This completes the A.2 hygiene work I'm doing. The remaining Group D nits (`verifiedFilter` "Filter" suffix, bulk-vs-single mark URL naming, `AlertNotificationFrequencyOut.id` -> `code`) are cosmetic and intentionally left as not worth the breaking churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)