### PR TITLE
Make tests immune to django-vite dev_mode; env-drive it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,3 +133,7 @@ SEND_NOTIFICATIONS_SCHEDULE=0 0 14 * * *
 # default settings module, e.g.:
 #GDAL_LIBRARY_PATH=/opt/homebrew/lib/libgdal.dylib
 #GEOS_LIBRARY_PATH=/opt/homebrew/lib/libgeos_c.dylib
+
+# Set to true ONLY for frontend dev with the Vite dev server (`npm run vite-dev`).
+# Leave unset/false in production and tests so the built bundle is served.
+#DJANGO_VITE_DEV_MODE=false

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,11 @@ import pytest
 # This flag disables that guard - safe in a test context.
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "1"
 
+# Tests must use the built Vite bundle, never the dev server. Force the env-driven
+# default off (the _force_vite_built_bundle fixture also overrides any
+# local_settings hardcode after settings load).
+os.environ["DJANGO_VITE_DEV_MODE"] = "False"
+
 
 def pytest_sessionstart(session):
     """Build the Vite bundle before any test runs.
@@ -21,6 +26,24 @@ def pytest_sessionstart(session):
         check=True,
         cwd=Path(__file__).parent,
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _force_vite_built_bundle():
+    """Force django-vite dev_mode off so Playwright uses the built bundle.
+
+    With dev_mode on (a developer running `npm run vite-dev` may set
+    DJANGO_VITE_DEV_MODE=true or hardcode it in local_settings.py), django-vite
+    emits dev-server <script> URLs that 404 in tests - the SPA never mounts and
+    every page times out. Override the final setting (after local_settings has
+    loaded) and reset django-vite's cached singleton so the built bundle from
+    pytest_sessionstart is actually served.
+    """
+    from django.conf import settings
+    from django_vite.core.asset_loader import DjangoViteAssetLoader
+
+    settings.DJANGO_VITE["default"]["dev_mode"] = False
+    DjangoViteAssetLoader._instance = None  # rebuild lazily with dev_mode off
 
 
 @pytest.fixture(autouse=True)

--- a/djangoproject/settings.py
+++ b/djangoproject/settings.py
@@ -329,7 +329,11 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 DJANGO_VITE = {
     "default": {
-        "dev_mode": False,  # override to True in local_settings.py when running the Vite dev server
+        # Set DJANGO_VITE_DEV_MODE=true in your .env when running the Vite dev
+        # server (`npm run vite-dev`). Defaults to False so the built bundle is
+        # used in production and in tests. (The test suite also force-disables
+        # dev_mode in conftest.py, so a stray True can't break Playwright.)
+        "dev_mode": os.environ.get("DJANGO_VITE_DEV_MODE", "False").lower() == "true",
         "dev_server_port": 5274,
         "manifest_path": BASE_DIR / "static_global" / "vite" / ".vite" / "manifest.json",
         # Vite outputs to static_global/vite/, so assets are served at /static/vite/...

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,3 +14,5 @@ ignore_missing_imports = True
 
 [mypy-taggit.*]
 ignore_missing_imports = True
+[mypy-django_vite.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Problem

With django-vite `dev_mode` on, it emits Vite **dev-server** `<script>` URLs (`http://localhost:5274/...`) instead of the built bundle. A developer running `npm run vite-dev` who sets `dev_mode=True` in their `local_settings.py` then has the **entire Playwright suite fail**: the SPA never mounts (no dev server during tests), so every test times out at `login()` waiting for `#signin-username`. Rebuilding the bundle doesn't help, because `dev_mode=True` ignores it.

## Fix

1. **`conftest.py` - tests can't be broken by `dev_mode`.** A session-autouse fixture forces `dev_mode=False` *after* `local_settings` has loaded and resets django-vite's cached singleton, so Playwright always uses the bundle built in `pytest_sessionstart`. (`DJANGO_VITE_DEV_MODE=False` is also set in the test env as belt-and-suspenders.)
2. **`settings.py` - env-drive `dev_mode`.** Read it from `DJANGO_VITE_DEV_MODE` (default `False`) instead of hardcoding in `local_settings.py`; flip it via `.env` when running the dev server. Documented in `.env.example`.
3. **`mypy.ini`** - `ignore_missing_imports` for `django_vite` (no `py.typed`).

## Migration note for your local setup

You can drop the `DJANGO_VITE["default"]["dev_mode"] = True` line from your `djangoproject/local_settings.py` and instead put `DJANGO_VITE_DEV_MODE=true` in your `.env` only while running `npm run vite-dev`. Either way, the test suite is now safe.

## Verification

- Full Playwright suite: **85 passed** even with `dev_mode=True` in `local_settings` (previously: all timed out at `login()`).
- mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)