### PR TITLE
Stamp a real version into the Docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute version string
+        id: version
+        run: echo "version=$(git describe --always --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,6 +51,8 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,8 +127,8 @@ The app provides an OGC Web Feature Service endpoint at `/api/wfs/observations` 
 - Feature branches → merge to `devel` → auto-deploys to demo server → merge to `main` → manual production deploy via `deploy_main.sh`
 - CI runs Django tests + mypy on every push (GitHub Actions)
 
-## Version Bumping
-Version number must be updated in three places: `pyproject.toml`, `package.json`, and `docker-compose.yml` (3 services: gbif-alert, rqworker, nginx).
+## Versioning
+The footer version is stamped into the Docker image at build time (`release.yml` uses the git tag; `image.yml` uses `git describe`), so no manual `VERSION` edit is needed - see CONTRIBUTING.md "How to release a new version". Bumping `pyproject.toml` / `package.json` is optional metadata only.
 
 ## Code Style
 - Python: `black` formatting, imports at top of file (stdlib → third-party → local), avoid local imports unless circular dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,24 +230,28 @@ If the cache is misconfigured or unreachable in production, `CacheBackend` logs 
 
 ## How to release a new version
 
-- Make sure all tests pass and mypy doesn't report any error
-- Update CHANGELOG.md
-- Update version number in `pyproject.toml`, `package.json`, `docker-compose.yml` (! 3 services: gbif-alert, rqworker and nginx) and `VERSION` (used to display the version in the footer - se the exact tag name with a 'v' here for correct footer link!)
-- ! The version number currently also appears in INSTALL.md
-- Commit, merge to main, push to GitHub
-- Create a new tag (e.g. `v1.1.0`) and push it:
-```
-$ git tag v1.1.0
-$ git push origin --tags
-```
-- Create a new Docker image and push it to Docker Hub (so end-users can reference it from docker-compose.yml):
-- (We also build a new version of the nginx image - even if unchanged - so the version number of the two images stay in sync)
-```
-$ docker build . -t niconoe/gbif-alert:1.1.0
-$ docker build ./nginx -t niconoe/gbif-alert-nginx:1.1.0
-$ docker push niconoe/gbif-alert:1.1.0
-$ docker push niconoe/gbif-alert-nginx:1.1.0
-```
+Releases are built and published automatically by `.github/workflows/release.yml`
+when a `v*` tag is pushed: the image is pushed to GHCR
+(`ghcr.io/riparias/gbif-alert`) and stamped with the tag, which the footer
+displays. No manual `VERSION` file edit is needed.
+
+1. Make sure all tests pass and `mypy` reports no errors.
+2. Update `CHANGELOG.md`.
+3. (Optional) Bump the version in `pyproject.toml` and `package.json` for
+   metadata consistency. These are no longer load-bearing for the footer.
+4. Commit, merge to `main`, push.
+5. Tag and push:
+   ```
+   $ git tag v1.1.0
+   $ git push origin v1.1.0
+   ```
+   This triggers `release.yml`, which builds and pushes
+   `ghcr.io/riparias/gbif-alert:1.1.0` (and `:latest`), stamped with the tag.
+6. Bump `GBIF_ALERT_TAG` on each instance (see INSTALL.md "Upgrades") to roll
+   the new image out.
+
+The footer version is auto-stamped: release images show the tag (`v1.1.0`);
+`devel`/`main` images show a `git describe` string (e.g. `v1.0.0-42-gabc123`).
 
 ## How to link to a GBIF alert instance with specific filters
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,14 @@ RUN SECRET_KEY=build-only \
     SITE_NAME=build \
     python manage.py compilemessages
 
+# Stamp the build version. Read at runtime by the footer via
+# dashboard.utils.human_readable_git_version_number(). Empty (a plain local
+# build with no --build-arg) writes an empty file, which the resolver treats
+# as absent and falls through - no regression. CI passes the real value:
+# release.yml -> the tag, image.yml -> `git describe --always --tags`.
+ARG VERSION=""
+RUN printf '%s' "$VERSION" > VERSION
+
 # Non-root user.
 RUN groupadd --system app && \
     useradd --system --gid app --home-dir /app --shell /usr/sbin/nologin app && \

--- a/dashboard/tests/test_version.py
+++ b/dashboard/tests/test_version.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import dashboard.utils
+from dashboard.utils import human_readable_git_version_number
+
+
+def test_version_file_is_read(tmp_path: Path, monkeypatch):
+    """A VERSION file at BASE_DIR takes precedence and is returned verbatim."""
+    monkeypatch.setattr(dashboard.utils, "_cached_version", None)
+    monkeypatch.setattr(dashboard.utils.settings, "BASE_DIR", tmp_path)
+    (tmp_path / "VERSION").write_text("v9.9.9-test\n")
+
+    assert human_readable_git_version_number() == "v9.9.9-test"
+
+
+def test_empty_version_file_falls_through(tmp_path: Path, monkeypatch):
+    """An empty VERSION file is treated as absent (does not return "")."""
+    monkeypatch.setattr(dashboard.utils, "_cached_version", None)
+    monkeypatch.setattr(dashboard.utils.settings, "BASE_DIR", tmp_path)
+    (tmp_path / "VERSION").write_text("")
+
+    # No VERSION value and no usable git repo at tmp_path -> "unknown", never "".
+    assert human_readable_git_version_number() != ""


### PR DESCRIPTION
## Summary

The deployed image footer shows "version unknown" because the image has no `VERSION` file and `.dockerignore` excludes `.git`, so `dashboard.utils.human_readable_git_version_number()` falls through. This stamps `VERSION` at build time, which that resolver already reads.

- **`Dockerfile`**: `ARG VERSION` + writes it to `/app/VERSION` (empty arg falls through gracefully).
- **`release.yml`** (tag-triggered): `VERSION=${{ github.ref_name }}` -> releases show the clean tag (e.g. `v2.0.0`). No ordering issue: the tag push *is* the trigger.
- **`image.yml`** (devel/main): `VERSION=$(git describe --always --tags)` with `fetch-depth: 0` -> e.g. `v1.9.0-437-g9812d62`.
- **Docs**: rewrote the stale CONTRIBUTING "How to release" (manual VERSION, nginx, Docker Hub all gone) and the parallel CLAUDE.md note to the actual automated GHCR flow.
- **Test**: `dashboard/tests/test_version.py` locks the resolver's VERSION-file behavior.

## Verification

- Local: `docker build --build-arg VERSION=v9.9.9-test` -> `cat VERSION` and the resolver both return `v9.9.9-test`.
- `git describe --always --tags` locally -> `v1.9.0-437-g9812d62`.
- New tests pass on 3.12 + 3.13 (CI).

## Out of scope
Manual (non-Docker) deploy already works via runtime `git describe`. Design: `work/gbif-alert/2026-06-10 image version stamping design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)