### PR TITLE
chore: pre-V2-RC infra hardening (DB parity, HTTPS, license, version SSOT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 # automatically via python-dotenv. Anything you do NOT set here can be
 # left as the documented default below.
 #
-# For the Docker stack (separate PR), the same variables are read from
-# the operator's `.env` next to `docker-compose.yml`.
+# For the Docker stack, the same variables are read from the operator's
+# `.env` next to `docker-compose.yml`.
 
 # === Required ===
 # `settings.py` raises ImproperlyConfigured at startup if any of these
@@ -105,6 +105,23 @@ RQ_REDIS_URL=redis://localhost:6379/0
 # falls back to redis://localhost:6379/0 - so a local Valkey/Redis
 # install with default ports just works.
 #CACHE_URL=
+
+# Security / HTTPS hardening. All optional. With DEBUG=False these default to
+# secure values suited to the standard "behind a TLS-terminating reverse
+# proxy" topology, so a normal HTTPS deploy needs none of them. They are here
+# for the rare cases that need to opt out or tune.
+#  - SESSION/CSRF cookie Secure flag and HTTP->HTTPS redirect default to True
+#    in production (DEBUG=False), False in dev. Set SECURE_SSL_REDIRECT=False
+#    if your reverse proxy already redirects HTTP to HTTPS.
+#  - HSTS defaults to 3600s (1h) in production with no includeSubDomains/
+#    preload. Raise it once confident; set to 0 to disable. Only enable
+#    includeSubDomains/preload deliberately - they are slow to undo.
+#SESSION_COOKIE_SECURE=True
+#CSRF_COOKIE_SECURE=True
+#SECURE_SSL_REDIRECT=True
+#SECURE_HSTS_SECONDS=3600
+#SECURE_HSTS_INCLUDE_SUBDOMAINS=False
+#SECURE_HSTS_PRELOAD=False
 
 # === Docker-only ===
 # Image tag pulled by the compose stack. REQUIRED - the compose file has no

--- a/.gitignore
+++ b/.gitignore
@@ -152,5 +152,3 @@ openapi-schema.json
 
 docs/superpowers
 .superpowers
-
-deploy.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Compose topology**: the custom nginx image and `static_volume` are removed. The app now serves static files via WhiteNoise. Operators need an external reverse proxy (Dokploy/Traefik, ALB, etc.) for TLS and public routing.
 - **Redis -> Valkey**: the in-compose broker is now Valkey (BSD-3-Clause). Same RESP protocol, drop-in for rq. The service name in compose changed from `redis` to `valkey`.
 - **Migrations** are now applied by a one-shot `migrate` service rather than at every container startup. Safer for multi-replica deployments.
+- **Bundled-db Postgres 15 -> 17**: the optional `bundled-db` compose profile now uses `postgis/postgis:17-3.5` (matching the version the test suite runs against), up from `15-3.3`. Existing bundled-db deployments must run `pg_upgrade` or a dump/restore before upgrading. Deployments using managed/external Postgres are unaffected.
 
 **Added:**
 
@@ -21,6 +22,7 @@
 - `bundled-db` compose profile so the postgis service is opt-in (production deploys typically use managed Postgres).
 - GitHub Actions workflows: build on every push to `main`/`devel`, publish versioned tags on `v*`.
 - `.env.example` documents the full env-var contract.
+- HTTPS hardening settings (`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, plus the `INCLUDE_SUBDOMAINS`/`PRELOAD` toggles): secure-by-default when `DEBUG=False`, env-overridable, with the internal `/healthz` healthcheck exempted from the HTTPS redirect. See `.env.example`.
 
 **Changed:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,11 +124,11 @@ The app provides an OGC Web Feature Service endpoint at `/api/wfs/observations` 
 
 ## Branching & Deployment
 - Never commit directly to `main`
-- Feature branches → merge to `devel` → auto-deploys to demo server → merge to `main` → manual production deploy via `deploy_main.sh`
+- Feature branches → merge to `devel` (auto-builds + redeploys the demo from the GHCR image) → merge to `main` → tag `v*` to publish a release image; production rolls forward by bumping `GBIF_ALERT_TAG` (see INSTALL.md "Upgrades")
 - CI runs Django tests + mypy on every push (GitHub Actions)
 
 ## Versioning
-The footer version is stamped into the Docker image at build time (`release.yml` uses the git tag; `image.yml` uses `git describe`), so no manual `VERSION` edit is needed - see CONTRIBUTING.md "How to release a new version". Bumping `pyproject.toml` / `package.json` is optional metadata only.
+The footer version is stamped into the Docker image at build time (`release.yml` uses the git tag; `image.yml` uses `git describe`), so no manual `VERSION` edit is needed - see CONTRIBUTING.md "How to release a new version". Bumping `pyproject.toml` is optional metadata only (`package.json` no longer carries a version).
 
 ## Code Style
 - Python: `black` formatting, imports at top of file (stdlib → third-party → local), avoid local imports unless circular dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ The current workflow is:
 3) `devel` is pushed to GitHub: the updated version can be tested on the development server and shared with stakeholders.
 4) after everything is confirmed ok, the `devel` branch is merged to `main`
 5) `main` is pushed to GitHub
-6) code is (currently) manually deployed in production via the `deploy_main.sh` script
+6) a release is published by tagging `v*` (see "How to release a new version" below); production rolls forward by bumping `GBIF_ALERT_TAG` to the new image (see INSTALL.md "Upgrades")
 
 For small, non-risky changes, steps 1-3 can be avoided by committing directly to the `devel` branch.
 
@@ -237,8 +237,9 @@ displays. No manual `VERSION` file edit is needed.
 
 1. Make sure all tests pass and `mypy` reports no errors.
 2. Update `CHANGELOG.md`.
-3. (Optional) Bump the version in `pyproject.toml` and `package.json` for
-   metadata consistency. These are no longer load-bearing for the footer.
+3. (Optional) Bump the version in `pyproject.toml` for metadata consistency.
+   It is no longer load-bearing for the footer (`package.json` no longer
+   carries a version).
 4. Commit, merge to `main`, push.
 5. Tag and push:
    ```

--- a/djangoproject/settings.py
+++ b/djangoproject/settings.py
@@ -83,6 +83,50 @@ CSRF_TRUSTED_ORIGINS = [
 # different proxy in front, verify it does the same before trusting this.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+# ---------------------------------------------------------------------------
+# HTTPS hardening.
+#
+# These only bite when the public site is served over HTTPS, which is the
+# supported production topology (DEBUG=False behind a TLS-terminating reverse
+# proxy). Each defaults to the secure value in production and a dev-friendly
+# value when DEBUG=True (runserver speaks plain HTTP), and each is
+# env-overridable for unusual setups - so the same image deploys cleanly on
+# Dokploy, AWS, bare compose, etc. without per-platform tweaks.
+_prod_https = not DEBUG
+
+# Secure-only cookies: the browser sends them over HTTPS only.
+SESSION_COOKIE_SECURE = (
+    os.environ.get("SESSION_COOKIE_SECURE", str(_prod_https)).lower() == "true"
+)
+CSRF_COOKIE_SECURE = (
+    os.environ.get("CSRF_COOKIE_SECURE", str(_prod_https)).lower() == "true"
+)
+
+# Redirect plain HTTP to HTTPS. Most reverse proxies already do this, so this
+# is belt-and-suspenders; operators whose proxy handles it can set
+# SECURE_SSL_REDIRECT=False to drop the extra hop. The internal compose
+# healthcheck hits http://localhost:8000/healthz directly (no proxy, no
+# X-Forwarded-Proto header), so it must be exempt - otherwise it gets 301'd to
+# https on a plain-HTTP port and the container is marked unhealthy.
+SECURE_SSL_REDIRECT = (
+    os.environ.get("SECURE_SSL_REDIRECT", str(_prod_https)).lower() == "true"
+)
+SECURE_REDIRECT_EXEMPT = [r"^healthz$"]
+
+# HTTP Strict Transport Security. Sticky and slow to undo (browsers cache it),
+# so the default is a conservative 1 hour with no includeSubDomains/preload.
+# Raise SECURE_HSTS_SECONDS once you are confident, and only enable
+# includeSubDomains/preload deliberately. Set SECURE_HSTS_SECONDS=0 to disable.
+SECURE_HSTS_SECONDS = int(
+    os.environ.get("SECURE_HSTS_SECONDS", "3600" if _prod_https else "0")
+)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = (
+    os.environ.get("SECURE_HSTS_INCLUDE_SUBDOMAINS", "False").lower() == "true"
+)
+SECURE_HSTS_PRELOAD = (
+    os.environ.get("SECURE_HSTS_PRELOAD", "False").lower() == "true"
+)
+
 SITE_BASE_URL = os.environ.get("SITE_BASE_URL", "")
 
 import dj_database_url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,10 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgis/postgis:15-3.3
+    # Kept in sync with the Postgres/PostGIS version the CI suite tests against
+    # (.github/workflows/django_tests.yml). Bumping the major version of an
+    # existing bundled-db deployment requires a dump/restore or pg_upgrade.
+    image: postgis/postgis:17-3.5
     profiles: ["bundled-db"]
     networks: [default]
     # POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB are required ONLY when

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbif-alert",
-  "version": "1.9.0",
+  "private": true,
   "description": "[![Django CI](https://github.com/riparias/early-alert-webapp/actions/workflows/django_tests.yml/badge.svg)](https://github.com/riparias/early-warning-webapp/actions/workflows/django_tests.yml)",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/riparias/gbif-alert/issues"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,4 +81,13 @@ env = [
     "D:ENABLED_LANGUAGES=en,fr",
     "D:GBIF_DOWNLOAD_COUNTRY=BE",
     "D:GBIF_DOWNLOAD_YEAR_MIN=2000",
+    # The suite runs with DEBUG=False (production-like) but over plain HTTP, so
+    # the production HTTPS hardening must be disabled here - otherwise
+    # SECURE_SSL_REDIRECT 301-redirects every test request to https, and the
+    # secure-cookie flags stop the Playwright browser from sending the
+    # session/CSRF cookies over http.
+    "D:SECURE_SSL_REDIRECT=False",
+    "D:SESSION_COOKIE_SECURE=False",
+    "D:CSRF_COOKIE_SECURE=False",
+    "D:SECURE_HSTS_SECONDS=0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "gbif-alert"
 version = "1.9.0"
 description = "A GBIF-based early alert system"
 authors = [{ name = "Nicolas Noé", email = "nicolas@niconoe.eu" }]
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Preliminary release-readiness fixes ahead of the V2 release candidate. Scoped to the **P0** items from the pre-V2 review - infra/config things that are easier to settle before the release than after.

## Changes

- **DB test/prod parity** - bundled-db compose image `postgis:15-3.3` -> `postgis:17-3.5`, matching the version CI tests against. Breaking for `bundled-db` deployments (needs `pg_upgrade` or dump/restore); managed-Postgres deployments unaffected. CHANGELOG breaking-note added.
- **HTTPS hardening** - env-configurable security settings in `settings.py` (`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS` + the subdomains/preload toggles). Secure-by-default when `DEBUG=False`, overridable per deployment, with `/healthz` exempted from the HTTPS redirect so the internal compose healthcheck keeps working. Resolves the `W004/W008/W012/W016` `check --deploy` warnings; HSTS `includeSubDomains`/`preload` deliberately left opt-in. Documented in `.env.example`.
- **License consistency** - MIT everywhere (`package.json` `ISC` -> `MIT`; declare `license` + `license-files` in `pyproject.toml`).
- **Version single source of truth** - drop the duplicate version from `package.json` (now `private: true`); `pyproject.toml` is canonical (footer version is auto-stamped from the git tag via the merged image-version-stamp work). Reconciled the residual "bump `package.json`" mentions in `CONTRIBUTING`/`CLAUDE.md`.
- **Obsolete deploy script** - removed references to the obsolete `deploy.sh` (ran `poetry` + the retired `--settings` flag) from `CONTRIBUTING`/`CLAUDE.md` and dropped its stale `.gitignore` entry.

## Validation

- `mypy` clean (91 files)
- `manage.py check` clean; `check --deploy` (production path) shows only the 2 intentional HSTS opt-in warnings
- `npm run vite-build` OK
- version-resolver test passes (confirms removing `package.json` version didn't break image stamping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)