### PR TITLE
chore: destale CLAUDE.md config docs + bump deprecated GH Action runtimes (P3)

### DIFF
--- a/.github/workflows/django_tests.yml
+++ b/.github/workflows/django_tests.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    # astral-sh/setup-uv has no Node 24 release yet (checkout@v5 / build-push@v6
+    # are already Node 24), so force the one remaining Node 20 JS action onto
+    # Node 24 to clear the runner's deprecation warning. Remove once setup-uv
+    # ships a Node 24 build, or after 2026-06-16 when Node 24 is the runner default.
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     strategy:
@@ -34,9 +38,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v6
       with:
         enable-cache: true
     - name: Install additional libraries

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,7 +45,7 @@ jobs:
             latest=auto
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,13 @@ GBIF Alert is a Django-based early alert system for invasive species using GBIF 
 ## Commands
 
 ### Django Settings
-To run `manage.py` commands (makemigrations, migrate, test, etc.), set the Django settings module:
-```bash
-export DJANGO_SETTINGS_MODULE=djangoproject.local_settings
-```
+The settings module is always `djangoproject.settings` (the `manage.py`/`wsgi`/`asgi`
+default) - just run `python manage.py <command>`, no `DJANGO_SETTINGS_MODULE` override
+needed. It loads `.env` from the project root, reads env vars (see `.env.example`), then
+imports an optional `djangoproject/local_settings.py` as an escape hatch on top.
+
+On macOS, GeoDjango needs explicit library paths - set `GDAL_LIBRARY_PATH` and
+`GEOS_LIBRARY_PATH` in `.env` (or `local_settings.py`).
 
 ### Setup
 ```bash
@@ -77,10 +80,10 @@ npm run generate-types  # Exports OpenAPI schema, writes assets/frontend/types/a
 ### Django Apps
 - **`dashboard/`** — Main app containing all core logic: models, views, templates, management commands, and tests
 - **`page_fragments/`** — Small app for admin-editable page content blocks (uses `templatetags` for rendering)
-- **`djangoproject/`** — Django project settings; instance-specific configuration goes in `local_settings.py` (copied from `local_settings.template.py`)
+- **`djangoproject/`** — Django project settings (`settings.py`), env-driven with an optional `local_settings.py` escape hatch (template: `local_settings.template.py`)
 
 ### Configuration System
-Each GBIF Alert instance is configured via `local_settings.py` which contains a `GBIF_ALERT` dict with site name, colors, enabled languages, GBIF download credentials, and a `PREDICATE_BUILDER` function that defines the GBIF search query. This is how different instances target different species/regions.
+Each GBIF Alert instance is configured via environment variables (see `.env.example`): `settings.py` builds the `GBIF_ALERT` dict (site name, palette, enabled languages, GBIF download credentials, map defaults) from them. Settings that can't be expressed as env vars - notably the `PREDICATE_BUILDER` callable that defines the GBIF search query - go in an optional `local_settings.py`, imported on top of the env-driven config. This is how different instances target different species/regions.
 
 ### Frontend-Backend Integration
 Single-page application: all pages are served by the `spa_shell` Django view, which injects a `gbif-alert-nav-config` JSON block (site name, enabled languages, auth state) and loads the Vite bundle. Vue Router (history mode) handles client-side routing. Pinia manages shared state (active filters). A Django catch-all pattern in `djangoproject/urls.py` forwards unmatched paths to the SPA shell.


### PR DESCRIPTION
Pre-V2-RC cleanup (P3). Two unrelated low-risk chores.

## CLAUDE.md - de-stale the config/settings docs
The repo `CLAUDE.md` still described the **pre-V2** config model: it told contributors to `export DJANGO_SETTINGS_MODULE=djangoproject.local_settings` (the **retired** entry point) and presented `local_settings.py` as the primary config mechanism. Rewritten to match the shipped env-driven model:
- Entry point is always `djangoproject.settings` (the `manage.py`/`wsgi`/`asgi` default) - no `DJANGO_SETTINGS_MODULE` override.
- Config comes from env vars (`.env.example`); `settings.py` builds the `GBIF_ALERT` dict from them.
- `local_settings.py` is kept as the **optional escape hatch** for Python callables (e.g. `PREDICATE_BUILDER`) - feature unchanged, just documented accurately.

## GitHub Actions - clear the Node 20 deprecation
Bumped the JS actions the runner flagged as Node-20:
- `actions/checkout` v4 -> v5 (now Node 24 native)
- `docker/build-push-action` v5 -> v6 (now Node 24 native)
- `astral-sh/setup-uv` v4 -> v6

**Note:** `setup-uv@v6` still ships on Node 20 (verified via the CI annotation - no Node-24 release exists yet), so the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround is **kept** - now scoped to that single remaining action with a comment - to clear the warning. Removable once setup-uv ships Node 24, or after 2026-06-16 when Node 24 is the runner default.

Left the `settings.py` "Generated by django-admin ... Django 3.2.6" header alone (honest history, per maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)