### PR TITLE
fix(settings): fail loudly on a malformed ADMINS env var

### DIFF
--- a/dashboard/tests/test_settings.py
+++ b/dashboard/tests/test_settings.py
@@ -422,3 +422,50 @@ def test_admins_parsed_from_env_string(clean_env):
     settings = _import_settings()
     assert ("Alice", "a@example.com") in settings.ADMINS
     assert ("Bob", "b@example.com") in settings.ADMINS
+
+
+def test_admins_bare_email_parsed(clean_env):
+    """A bare email (no `Name <...>` wrapper) is accepted, with the email
+    used as both the name and the address."""
+    _minimal_env(clean_env)
+    clean_env.setenv("ADMINS", "ops@example.com")
+    settings = _import_settings()
+    assert ("ops@example.com", "ops@example.com") in settings.ADMINS
+
+
+def test_admins_python_literal_raises_improperly_configured(clean_env):
+    """Pasting a Python list literal (the form used in `local_settings.py`)
+    into the `ADMINS` env var must fail loudly at startup.
+
+    `ADMINS` is an environment-variable string, not Python code: a literal
+    like `[("Nicolas Noe", "nicolas@niconoe.eu")]` gets split on commas into
+    fragments such as `[` and `]` that are not valid addresses. Previously
+    these were silently kept and only blew up days later inside
+    `mail_admins()` during a data import (`Invalid address "["`). The
+    settings module must reject them at boot instead.
+    """
+    _minimal_env(clean_env)
+    clean_env.setenv(
+        "ADMINS", '[("Nicolas Noe", "nicolas@niconoe.eu")]'
+    )
+    with pytest.raises(ImproperlyConfigured) as exc_info:
+        _import_settings()
+    # The message must name the offending input and the expected format so the
+    # operator can fix the env var without reading the source.
+    assert "ADMINS" in str(exc_info.value)
+
+
+def test_admins_invalid_email_raises_improperly_configured(clean_env):
+    """Any entry whose address is not a valid email aborts startup."""
+    _minimal_env(clean_env)
+    clean_env.setenv("ADMINS", "Alice <not-an-email>")
+    with pytest.raises(ImproperlyConfigured):
+        _import_settings()
+
+
+def test_admins_unset_is_empty_list(clean_env):
+    """An unset `ADMINS` is valid and yields an empty list (no error emails,
+    but the app boots fine)."""
+    _minimal_env(clean_env)
+    settings = _import_settings()
+    assert settings.ADMINS == []

--- a/djangoproject/settings.py
+++ b/djangoproject/settings.py
@@ -160,20 +160,39 @@ SERVER_EMAIL = os.environ.get("SERVER_EMAIL", DEFAULT_FROM_EMAIL)
 EMAIL_SUBJECT_PREFIX = os.environ.get("EMAIL_SUBJECT_PREFIX", "[gbif-alert] ")
 
 # ADMINS is parsed from a single env var of the form "Name1 <a@b>, Name2 <c@d>"
+# (or bare emails). It is an environment-variable STRING, not Python code -
+# pasting a list literal like `[("Name", "a@b")]` (the form used in
+# local_settings.py) splits on commas into fragments such as "[" and "]" that
+# are not valid addresses. Rather than silently keeping that garbage - which
+# only blows up days later inside mail_admins() during a data import
+# (`Invalid address "["`) - validate each entry and fail fast at startup.
 _admins_raw = os.environ.get("ADMINS", "")
 ADMINS: list[tuple[str, str]] = []
 if _admins_raw:
     import re
+    from django.core.exceptions import ImproperlyConfigured, ValidationError
+    from django.core.validators import validate_email
+
     for entry in _admins_raw.split(","):
         entry = entry.strip()
         if not entry:
             continue
         match = re.match(r"^(.*?)\s*<(.+?)>$", entry)
         if match:
-            ADMINS.append((match.group(1).strip(), match.group(2).strip()))
+            name, email = match.group(1).strip(), match.group(2).strip()
         else:
             # Bare email: name = email
-            ADMINS.append((entry, entry))
+            name, email = entry, entry
+        try:
+            validate_email(email)
+        except ValidationError:
+            raise ImproperlyConfigured(
+                f"Invalid ADMINS entry: {entry!r}. ADMINS must be a comma-"
+                f'separated string of the form "Name <a@b.c>, Name2 <d@e.f>" '
+                f"(or bare emails). It is an environment-variable string, not a "
+                f"Python list literal."
+            )
+        ADMINS.append((name, email))
 
 # ---------------------------------------------------------------------------
 # GBIF_ALERT settings (per-deployment branding, behaviour, and GBIF download


### PR DESCRIPTION
## What

The `ADMINS` setting is parsed from a single environment-variable string of the form `"Name <a@b>, Name2 <c@d>"` (or bare emails). It is **not** Python code: pasting a list literal like `[("Nicolas Noe", "nicolas@niconoe.eu")]` (the form used in `local_settings.py`) splits on commas into fragments such as `[` and `]` that are not valid addresses.

Previously these fragments were silently kept as `ADMINS` entries and only blew up days later inside `mail_admins()` during a data import:

```
ValueError: Invalid address "["
```

This PR validates each entry's email and raises `ImproperlyConfigured` at startup, naming the offending entry and the expected format - consistent with how `SECRET_KEY`/`DATABASE_URL` already fail fast in this settings module.

## Behavior change

A malformed `ADMINS` now stops the **whole app** from booting (web included), not just the import job's email. That is the point of "fail louder": it surfaces immediately at deploy time, on every container, instead of latently. The valid string form (`ADMINS=Nicolas Noe <nicolas@niconoe.eu>`) and an unset `ADMINS` are unaffected.

## Tests

`dashboard/tests/test_settings.py`, via the existing env-driven re-import harness:
- `test_admins_python_literal_raises_improperly_configured` - the exact `[("Nicolas Noe", ...)]` literal now aborts boot (red before this change)
- `test_admins_invalid_email_raises_improperly_configured` - `Alice <not-an-email>` aborts boot
- `test_admins_bare_email_parsed` / `test_admins_unset_is_empty_list` - pin the still-valid lenient paths so the stricter parser does not over-reject

All 17 tests in `test_settings.py` pass; mypy clean on `settings.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)