### PR TITLE
Replace flaky networkidle waits with web-first assertions

### DIFF
--- a/dashboard/tests/playwright/conftest.py
+++ b/dashboard/tests/playwright/conftest.py
@@ -18,6 +18,16 @@ and must be overridden before any HTTP requests are made:
 """
 
 import pytest
+from playwright.sync_api import expect
+
+
+# Web-first assertions (expect(...).to_be_visible(), etc.) default to a 5s
+# timeout. Now that the suite no longer waits for the (flaky, deprecated)
+# "networkidle" load state and instead relies on these assertions to
+# synchronise, bump the default so a cold SPA boot in CI - Vue mount plus the
+# first data fetch - has enough headroom before an assertion is judged failed.
+# Actions (click/fill) keep Playwright's own 30s default.
+expect.set_options(timeout=15_000)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/dashboard/tests/playwright/helpers.py
+++ b/dashboard/tests/playwright/helpers.py
@@ -19,11 +19,12 @@ def login(page: Page, base_url: str, username: str, password: str) -> None:
     depending on timing.
     """
     page.goto(base_url + "/accounts/signin/")
-    page.wait_for_load_state("networkidle")
+    # No explicit load-state wait: .fill() below auto-waits for the field.
     page.locator("#signin-username").fill(username)
     page.locator("#signin-password").fill(password)
     page.get_by_role("button", name="Sign in").click()
+    # wait_until defaults to "load"; we already gate on the URL predicate, which
+    # is the deterministic signal that the post-login redirect has committed.
     page.wait_for_url(
         lambda url: url == base_url + "/" or url.startswith(base_url + "/?"),
-        wait_until="networkidle",
     )

--- a/dashboard/tests/playwright/test_alert_templates.py
+++ b/dashboard/tests/playwright/test_alert_templates.py
@@ -22,7 +22,6 @@ def test_user_creates_alert_from_template(page: Page, live_server):
     User.objects.create_user(username="jane", password="pass", email="jane@e.com")
     login(page, live_server.url, "jane", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("Amphibians near X", exact=False)).to_be_visible()
 
@@ -52,33 +51,43 @@ def test_publish_button_visible_only_to_superuser(page: Page, live_server):
     User = get_user_model()
     op = User.objects.create_superuser(username="op", password="pass", email="op@e.com")
     sp = Species.objects.create(name="Procambarus fallax", gbif_taxon_key=8879526)
-    alert = Alert.objects.create(name="seed", user=op, email_notifications_frequency="N")
+    alert = Alert.objects.create(
+        name="seed", user=op, email_notifications_frequency="N"
+    )
     alert.species.add(sp)
 
     login(page, live_server.url, "op", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
-    expect(page.get_by_role("button", name="Publish as template", exact=False)).to_be_visible()
+    expect(
+        page.get_by_role("button", name="Publish as template", exact=False)
+    ).to_be_visible()
 
 
 @pytest.mark.django_db(transaction=True)
 def test_publish_button_hidden_for_non_superuser(page: Page, live_server):
     User = get_user_model()
-    jane = User.objects.create_user(username="jane", password="pass", email="jane@e.com")
+    jane = User.objects.create_user(
+        username="jane", password="pass", email="jane@e.com"
+    )
     sp = Species.objects.create(name="Procambarus fallax", gbif_taxon_key=8879526)
-    alert = Alert.objects.create(name="jane's alert", user=jane, email_notifications_frequency="N")
+    alert = Alert.objects.create(
+        name="jane's alert", user=jane, email_notifications_frequency="N"
+    )
     alert.species.add(sp)
 
     login(page, live_server.url, "jane", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     # Sanity check: the page actually rendered for this user (sidebar actions are
     # only shown to authenticated users), so the absence of the publish button below
     # is a real assertion about the superuser gate, not a false negative from a
     # failed page load.
-    expect(page.get_by_role("button", name="Edit this alert", exact=False)).to_be_visible()
-    expect(page.get_by_role("button", name="Publish as template", exact=False)).to_have_count(0)
+    expect(
+        page.get_by_role("button", name="Edit this alert", exact=False)
+    ).to_be_visible()
+    expect(
+        page.get_by_role("button", name="Publish as template", exact=False)
+    ).to_have_count(0)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -89,7 +98,9 @@ def test_expanded_template_card_species_list_does_not_overflow(page: Page, live_
     User = get_user_model()
     op = User.objects.create_superuser(username="op", password="pass", email="op@e.com")
     species = [
-        Species.objects.create(name=f"Genus longspeciesname{i}", gbif_taxon_key=900000 + i)
+        Species.objects.create(
+            name=f"Genus longspeciesname{i}", gbif_taxon_key=900000 + i
+        )
         for i in range(20)
     ]
     seed = Alert.objects.create(name="many", user=op, email_notifications_frequency="N")
@@ -101,7 +112,6 @@ def test_expanded_template_card_species_list_does_not_overflow(page: Page, live_
     User.objects.create_user(username="bob", password="pass", email="bob@e.com")
     login(page, live_server.url, "bob", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     card = page.locator(".template-card").filter(has_text="Many species template")
     card.get_by_role("button", name="Details", exact=False).click()
@@ -129,7 +139,6 @@ def test_operator_publishes_then_user_creates_from_it(page: Page, live_server):
     # Operator publishes the alert as a template from its detail page.
     login(page, live_server.url, "op", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
     page.get_by_role("button", name="Publish as template", exact=False).click()
     expect(page.get_by_text("Template published", exact=False)).to_be_visible()
     assert AlertTemplate.objects.count() == 1
@@ -139,7 +148,6 @@ def test_operator_publishes_then_user_creates_from_it(page: Page, live_server):
     page.context.clear_cookies()
     login(page, live_server.url, "jane", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     card = page.locator(".template-card").filter(has_text="Crayfish of Wallonia")
     expect(card).to_be_visible()
@@ -168,7 +176,9 @@ def test_from_template_duplicate_name_shows_error_in_dialog(page: Page, live_ser
     tpl.name_en = "Reusable template"  # type: ignore[attr-defined]
     tpl.save()
 
-    jane = User.objects.create_user(username="jane", password="pass", email="jane@e.com")
+    jane = User.objects.create_user(
+        username="jane", password="pass", email="jane@e.com"
+    )
     clash = Alert.objects.create(
         name="Existing name", user=jane, email_notifications_frequency="N"
     )
@@ -176,7 +186,6 @@ def test_from_template_duplicate_name_shows_error_in_dialog(page: Page, live_ser
 
     login(page, live_server.url, "jane", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     card = page.locator(".template-card").filter(has_text="Reusable template")
     card.get_by_role("button", name="Use this template", exact=False).click()

--- a/dashboard/tests/playwright/test_alerts.py
+++ b/dashboard/tests/playwright/test_alerts.py
@@ -146,6 +146,10 @@ def test_create_alert_succeeds(page: Page, live_server):
     login(page, live_server.url, "u6", "pass")
     page.goto(live_server.url + "/new-alert")
 
+    # Wait for the form to finish initialising (the suggested name is fetched and
+    # pre-filled asynchronously) before submitting, so the create carries a name.
+    expect(page.locator("#alert-name")).to_have_value("My alert #1")
+
     # Open the species modal and select a species
     page.get_by_role("button", name="All species").click()
     page.get_by_role("row", name="Procambarus fallax").click()
@@ -173,6 +177,12 @@ def test_create_alert_shows_error_when_no_species(page: Page, live_server):
 
     login(page, live_server.url, "u7", "pass")
     page.goto(live_server.url + "/new-alert")
+
+    # Wait for the form to finish initialising (suggested name pre-filled) before
+    # submitting, so the only validation error is the missing-species one -
+    # otherwise we race the async name pre-fill and also get a "name blank"
+    # message, and the assertion below hits two elements (strict-mode violation).
+    expect(page.locator("#alert-name")).to_have_value("My alert #1")
 
     # The PrimeVue error Message for species must NOT be present before submission
     # (only the static field-hint paragraph is shown at this point).
@@ -217,6 +227,10 @@ def test_edit_alert_saves_changes(page: Page, live_server):
     page.goto(live_server.url + f"/edit-alert/{alert.pk}")
 
     name_input = page.locator("#alert-name")
+    # Wait for the alert's data (name + species) to load into the form before
+    # editing; otherwise Save posts an incomplete alert (422 - no species) or the
+    # late GET clobbers the typed value.
+    expect(name_input).to_have_value("Original name")
     name_input.click(click_count=3)
     name_input.fill("Updated alert name")
 

--- a/dashboard/tests/playwright/test_alerts.py
+++ b/dashboard/tests/playwright/test_alerts.py
@@ -54,7 +54,6 @@ def test_my_alerts_page_shows_alert_list(page: Page, live_server):
 
     login(page, live_server.url, "u1", "pass")
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("My test alert")).to_be_visible()
     expect(page.get_by_text("Procambarus fallax")).to_be_visible()
@@ -68,7 +67,6 @@ def test_my_alerts_empty_state(page: Page, live_server):
 
     login(page, live_server.url, "u2", "pass")
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
 
     expect(
         page.get_by_text("don't currently have any configured alerts", exact=False)
@@ -79,7 +77,6 @@ def test_my_alerts_empty_state(page: Page, live_server):
 def test_my_alerts_page_requires_login(page: Page, live_server):
     """Anonymous user is redirected away from /my-alerts."""
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
     # Should be redirected to sign-in
     expect(page).not_to_have_url(live_server.url + "/my-alerts")
 
@@ -92,9 +89,7 @@ def test_my_alerts_navigate_to_create(page: Page, live_server):
 
     login(page, live_server.url, "u3", "pass")
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
     page.get_by_text("Create a new alert").first.click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/new-alert")
 
@@ -109,16 +104,16 @@ def test_my_alerts_delete_alert(page: Page, live_server):
 
     login(page, live_server.url, "u4", "pass")
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete this alert").click()
     # ConfirmDialog appears
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
     # Wait for the alert card to disappear (the dialog title also contains the
     # name, so scope the check to the card container specifically).
-    expect(page.locator(".alert-card").filter(has_text="Alert to delete")).not_to_be_visible()
+    expect(
+        page.locator(".alert-card").filter(has_text="Alert to delete")
+    ).not_to_be_visible()
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +130,6 @@ def test_create_alert_form_renders(page: Page, live_server):
 
     login(page, live_server.url, "u5", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     # Name input is pre-filled with the suggested name
     name_input = page.locator("#alert-name")
@@ -151,7 +145,6 @@ def test_create_alert_succeeds(page: Page, live_server):
 
     login(page, live_server.url, "u6", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     # Open the species modal and select a species
     page.get_by_role("button", name="All species").click()
@@ -180,14 +173,12 @@ def test_create_alert_shows_error_when_no_species(page: Page, live_server):
 
     login(page, live_server.url, "u7", "pass")
     page.goto(live_server.url + "/new-alert")
-    page.wait_for_load_state("networkidle")
 
     # The PrimeVue error Message for species must NOT be present before submission
     # (only the static field-hint paragraph is shown at this point).
     expect(page.locator("[data-pc-name='message']")).not_to_be_visible()
 
     page.get_by_role("button", name="Create alert").click()
-    page.wait_for_load_state("networkidle")
 
     # After submitting with no species the server returns a validation error and
     # the PrimeVue <Message> component (data-pc-name="message") becomes visible.
@@ -209,7 +200,6 @@ def test_edit_alert_form_pre_fills_existing_data(page: Page, live_server):
 
     login(page, live_server.url, "u8", "pass")
     page.goto(live_server.url + f"/edit-alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     name_input = page.locator("#alert-name")
     expect(name_input).to_have_value("Existing alert name")
@@ -225,7 +215,6 @@ def test_edit_alert_saves_changes(page: Page, live_server):
 
     login(page, live_server.url, "u12", "pass")
     page.goto(live_server.url + f"/edit-alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     name_input = page.locator("#alert-name")
     name_input.click(click_count=3)
@@ -250,7 +239,6 @@ def test_my_alerts_delete_cancel_keeps_alert(page: Page, live_server):
 
     login(page, live_server.url, "u13", "pass")
     page.goto(live_server.url + "/my-alerts")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete this alert").click()
     # ConfirmDialog appears - dismiss it
@@ -275,7 +263,6 @@ def test_alert_detail_page_renders(page: Page, live_server):
 
     login(page, live_server.url, "u9", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("My detail alert").first).to_be_visible()
     expect(page.get_by_text("Procambarus fallax").first).to_be_visible()
@@ -291,10 +278,8 @@ def test_alert_detail_edit_button_navigates(page: Page, live_server):
 
     login(page, live_server.url, "u10", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Edit this alert").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + f"/edit-alert/{alert.pk}")
 
@@ -309,11 +294,9 @@ def test_alert_detail_delete_navigates_to_my_alerts(page: Page, live_server):
 
     login(page, live_server.url, "u11", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete this alert").click()
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/my-alerts")
     assert not Alert.objects.filter(pk=alert.pk).exists()
@@ -359,7 +342,6 @@ def test_alert_detail_mark_all_as_viewed(page: Page, live_server, monkeypatch):
 
     login(page, live_server.url, "u12", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Mark all as viewed").click()
     page.get_by_role("button", name="Yes, I'm sure").click()
@@ -384,7 +366,6 @@ def test_alert_detail_mark_all_button_hidden_when_no_unseen(page: Page, live_ser
 
     login(page, live_server.url, "u13", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_role("button", name="Mark all as viewed")).to_have_count(0)
 
@@ -416,7 +397,6 @@ def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server)
 
     login(page, live_server.url, "u14", "pass")
     page.goto(live_server.url + f"/alert/{alert.pk}")
-    page.wait_for_load_state("networkidle")
 
     # The bulk button is visible (1 unseen observation matches).
     bulk_btn = page.get_by_role("button", name="Mark all as viewed")
@@ -424,22 +404,25 @@ def test_alert_detail_drawer_refreshes_list_and_sidebar(page: Page, live_server)
 
     # Switch to the table tab so we can click the row.
     page.get_by_role("tab", name="Table").click()
-    page.wait_for_load_state("networkidle")
 
-    # Open the drawer by clicking the species cell in the row.
-    page.get_by_role("cell", name=re.compile("Procambarus fallax", re.I)).first.click()
-    # Wait for the drawer to actually open and its detail content to render before
-    # closing. networkidle alone is unreliable here: the page is already idle from
-    # load, so it resolves before the drawer fires its detail GET + mark-as-viewed
-    # POST, and an immediate Escape would race (and cancel) those requests.
+    # Open the drawer by clicking the species cell in the row. Opening it fires a
+    # detail GET followed by the mark-as-viewed POST; wait for that POST to
+    # complete before closing, so the close-triggered refresh reads the updated
+    # seen state. Deterministic replacement for a flaky networkidle wait: the page
+    # was already idle from load, so networkidle resolved before the POST fired.
+    with page.expect_response(
+        lambda r: "/mark-as-viewed/" in r.url and r.request.method == "POST"
+    ):
+        page.get_by_role(
+            "cell", name=re.compile("Procambarus fallax", re.I)
+        ).first.click()
+
     drawer = page.locator('[data-pc-name="drawer"]')
     expect(drawer).to_be_visible()
     expect(drawer.get_by_text("Procambarus fallax").first).to_be_visible()
-    page.wait_for_load_state("networkidle")
 
     # Close the drawer (Escape works for PrimeVue Drawer).
     page.keyboard.press("Escape")
-    page.wait_for_load_state("networkidle")
 
     # The (now-seen) observation no longer matches the status=notViewed filter:
     # the row is gone and the bulk button disappears (notViewedCount == 0).

--- a/dashboard/tests/playwright/test_areas.py
+++ b/dashboard/tests/playwright/test_areas.py
@@ -39,7 +39,6 @@ def test_my_areas_page_shows_area_list(page: Page, live_server):
 
     login(page, live_server.url, "a1", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("My polygon area")).to_be_visible()
 
@@ -54,7 +53,6 @@ def test_area_card_shows_tags(page: Page, live_server):
 
     login(page, live_server.url, "t1", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("woodland", exact=True)).to_be_visible()
     expect(page.get_by_text("protected", exact=True)).to_be_visible()
@@ -68,18 +66,14 @@ def test_my_areas_empty_state(page: Page, live_server):
 
     login(page, live_server.url, "a2", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
-    expect(
-        page.get_by_text("don't have any custom areas", exact=False)
-    ).to_be_visible()
+    expect(page.get_by_text("don't have any custom areas", exact=False)).to_be_visible()
 
 
 @pytest.mark.django_db(transaction=True)
 def test_my_areas_page_requires_login(page: Page, live_server):
     """Anonymous user is redirected away from /my-custom-areas."""
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
     expect(page).not_to_have_url(live_server.url + "/my-custom-areas")
 
 
@@ -97,13 +91,13 @@ def test_delete_area_confirmed(page: Page, live_server):
 
     login(page, live_server.url, "a4", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete").click()
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
-    expect(page.locator(".area-card").filter(has_text="Area to delete")).not_to_be_visible()
+    expect(
+        page.locator(".area-card").filter(has_text="Area to delete")
+    ).not_to_be_visible()
     assert not Area.objects.filter(pk=area.pk).exists()
 
 
@@ -116,7 +110,6 @@ def test_delete_area_cancelled(page: Page, live_server):
 
     login(page, live_server.url, "a5", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete").click()
     page.get_by_role("button", name="Cancel").click()
@@ -139,18 +132,20 @@ def test_delete_area_with_alert_shows_error(page: Page, live_server):
 
     login(page, live_server.url, "a8", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete").click()
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
     # Error toast must be visible
     expect(page.locator(".p-toast")).to_be_visible()
-    expect(page.locator(".p-toast")).to_contain_text("Cannot delete area", ignore_case=True)
+    expect(page.locator(".p-toast")).to_contain_text(
+        "Cannot delete area", ignore_case=True
+    )
 
     # Area is still in the list
-    expect(page.locator(".area-card").filter(has_text="Area with alert")).to_be_visible()
+    expect(
+        page.locator(".area-card").filter(has_text="Area with alert")
+    ).to_be_visible()
     assert Area.objects.filter(pk=area.pk).exists()
 
 
@@ -167,7 +162,6 @@ def test_create_area_succeeds(page: Page, live_server):
 
     login(page, live_server.url, "a6", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Add area").click()
     page.get_by_text("Upload file").click()
@@ -176,7 +170,6 @@ def test_create_area_succeeds(page: Page, live_server):
     page.locator("#area-name").fill("My uploaded area")
     page.locator("input[type=file]").set_input_files(POLYGON_GPKG)
     page.get_by_role("button", name="Upload").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("My uploaded area")).to_be_visible()
 
@@ -189,7 +182,6 @@ def test_create_area_invalid_file_shows_error(page: Page, live_server):
 
     login(page, live_server.url, "a7", "pass")
     page.goto(live_server.url + "/my-custom-areas")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Add area").click()
     page.get_by_text("Upload file").click()
@@ -197,7 +189,6 @@ def test_create_area_invalid_file_shows_error(page: Page, live_server):
     page.locator("#area-name").fill("Bad area")
     page.locator("input[type=file]").set_input_files(POINT_GPKG)
     page.get_by_role("button", name="Upload").click()
-    page.wait_for_load_state("networkidle")
 
     # Dialog stays open and shows an error
     expect(page.locator("[data-testid='area-upload-error']")).to_be_visible()
@@ -216,7 +207,6 @@ def test_editor_create_mode_loads(page: Page, live_server):
 
     login(page, live_server.url, "e1", "pass")
     page.goto(live_server.url + "/my-custom-areas/new")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator("#editor-area-name")).to_be_visible()
     expect(page.get_by_role("button", name="Draw polygon")).to_be_visible()
@@ -234,7 +224,6 @@ def test_editor_create_mode_loads(page: Page, live_server):
 def test_editor_create_mode_requires_login(page: Page, live_server):
     """Anonymous user is redirected away from the create editor."""
     page.goto(live_server.url + "/my-custom-areas/new")
-    page.wait_for_load_state("networkidle")
     expect(page).not_to_have_url(live_server.url + "/my-custom-areas/new")
 
 
@@ -252,7 +241,6 @@ def test_editor_edit_mode_prefills_name(page: Page, live_server):
 
     login(page, live_server.url, "e2", "pass")
     page.goto(live_server.url + f"/my-custom-areas/{area.pk}/edit")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator("#editor-area-name")).to_have_value("Prefilled area")
     expect(page.get_by_role("button", name="Delete area")).to_be_visible()
@@ -267,11 +255,9 @@ def test_editor_edit_mode_rename_and_save(page: Page, live_server):
 
     login(page, live_server.url, "e3", "pass")
     page.goto(live_server.url + f"/my-custom-areas/{area.pk}/edit")
-    page.wait_for_load_state("networkidle")
 
     page.locator("#editor-area-name").fill("New name")
     page.get_by_role("button", name="Save").click()
-    page.wait_for_load_state("networkidle")
 
     # Should redirect back to the list page
     expect(page).to_have_url(live_server.url + "/my-custom-areas")
@@ -289,12 +275,10 @@ def test_editor_delete_area_button(page: Page, live_server):
 
     login(page, live_server.url, "e4", "pass")
     page.goto(live_server.url + f"/my-custom-areas/{area.pk}/edit")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Delete area").click()
     # PrimeVue ConfirmDialog - click the accept button
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/my-custom-areas")
     assert not Area.objects.filter(pk=area.pk).exists()
@@ -309,9 +293,7 @@ def test_editor_cancel_returns_to_list(page: Page, live_server):
 
     login(page, live_server.url, "e5", "pass")
     page.goto(live_server.url + f"/my-custom-areas/{area.pk}/edit")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("button", name="Cancel").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/my-custom-areas")

--- a/dashboard/tests/playwright/test_areas.py
+++ b/dashboard/tests/playwright/test_areas.py
@@ -256,7 +256,11 @@ def test_editor_edit_mode_rename_and_save(page: Page, live_server):
     login(page, live_server.url, "e3", "pass")
     page.goto(live_server.url + f"/my-custom-areas/{area.pk}/edit")
 
-    page.locator("#editor-area-name").fill("New name")
+    editor_name = page.locator("#editor-area-name")
+    # Wait for the area to load into the form before renaming; otherwise the late
+    # GET clobbers the typed value (or Save posts stale data).
+    expect(editor_name).to_have_value("Old name")
+    editor_name.fill("New name")
     page.get_by_role("button", name="Save").click()
 
     # Should redirect back to the list page

--- a/dashboard/tests/playwright/test_auth.py
+++ b/dashboard/tests/playwright/test_auth.py
@@ -19,9 +19,7 @@ def test_signin_succeeds(page: Page, live_server):
 
     # Path should be "/"; a trailing "?status=all" may appear because of
     # IndexPage's useFilterSync debounced URL sync.
-    expect(page).to_have_url(
-        re.compile(rf"^{re.escape(live_server.url)}/(\?.*)?$")
-    )
+    expect(page).to_have_url(re.compile(rf"^{re.escape(live_server.url)}/(\?.*)?$"))
     expect(page.get_by_text("auth1")).to_be_visible()
 
 
@@ -32,11 +30,9 @@ def test_signin_wrong_password(page: Page, live_server):
     User.objects.create_user(username="auth2", password="correct", email="auth2@t.com")
 
     page.goto(live_server.url + "/accounts/signin/")
-    page.wait_for_load_state("networkidle")
     page.locator("#signin-username").fill("auth2")
     page.locator("#signin-password").fill("wrong")
     page.get_by_role("button", name="Sign in").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator("[data-testid='signin-error']")).to_be_visible()
     expect(page).to_have_url(live_server.url + "/accounts/signin/")
@@ -48,13 +44,11 @@ def test_signup_succeeds(page: Page, live_server):
     User = get_user_model()
 
     page.goto(live_server.url + "/signup")
-    page.wait_for_load_state("networkidle")
     page.locator("#su-username").fill("newauth3")
     page.locator("#su-email").fill("newauth3@t.com")
     page.locator("#su-password1").fill("Secure1234!")
     page.locator("#su-password2").fill("Secure1234!")
     page.get_by_role("button", name="Sign up").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/")
     assert User.objects.filter(username="newauth3").exists()
@@ -67,13 +61,11 @@ def test_signup_duplicate_username_shows_error(page: Page, live_server):
     User.objects.create_user(username="existing", password="pass", email="ex@t.com")
 
     page.goto(live_server.url + "/signup")
-    page.wait_for_load_state("networkidle")
     page.locator("#su-username").fill("existing")
     page.locator("#su-email").fill("other@t.com")
     page.locator("#su-password1").fill("Secure1234!")
     page.locator("#su-password2").fill("Secure1234!")
     page.get_by_role("button", name="Sign up").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/signup")
     expect(page.get_by_text("already exists", exact=False)).to_be_visible()
@@ -83,17 +75,17 @@ def test_signup_duplicate_username_shows_error(page: Page, live_server):
 def test_password_change_succeeds(page: Page, live_server):
     """Valid password change shows a success toast."""
     User = get_user_model()
-    User.objects.create_user(username="auth5", password="OldPass123!", email="auth5@t.com")
+    User.objects.create_user(
+        username="auth5", password="OldPass123!", email="auth5@t.com"
+    )
 
     login(page, live_server.url, "auth5", "OldPass123!")
     page.goto(live_server.url + "/accounts/password-change/")
-    page.wait_for_load_state("networkidle")
 
     page.locator("#cp-old").fill("OldPass123!")
     page.locator("#cp-new1").fill("NewPass456!")
     page.locator("#cp-new2").fill("NewPass456!")
     page.get_by_role("button", name="Change password").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".p-toast")).to_be_visible()
     expect(page.locator(".p-toast")).to_contain_text("password", ignore_case=True)
@@ -103,16 +95,16 @@ def test_password_change_succeeds(page: Page, live_server):
 def test_password_change_wrong_old_password(page: Page, live_server):
     """Wrong old password shows a field error."""
     User = get_user_model()
-    User.objects.create_user(username="auth6", password="Correct123!", email="auth6@t.com")
+    User.objects.create_user(
+        username="auth6", password="Correct123!", email="auth6@t.com"
+    )
 
     login(page, live_server.url, "auth6", "Correct123!")
     page.goto(live_server.url + "/accounts/password-change/")
-    page.wait_for_load_state("networkidle")
 
     page.locator("#cp-old").fill("wrong")
     page.locator("#cp-new1").fill("NewPass456!")
     page.locator("#cp-new2").fill("NewPass456!")
     page.get_by_role("button", name="Change password").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("incorrect", exact=False)).to_be_visible()

--- a/dashboard/tests/playwright/test_index_page.py
+++ b/dashboard/tests/playwright/test_index_page.py
@@ -75,7 +75,6 @@ def _make_observation(
 
 def _switch_to_table_view(page: Page) -> None:
     page.get_by_role("tab", name="Table").click()
-    page.wait_for_load_state("networkidle")
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +86,6 @@ def _switch_to_table_view(page: Page) -> None:
 def test_index_page_renders(page: Page, live_server):
     """The index page loads: sidebar filter panel and stat block are visible."""
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
     expect(page.get_by_text("FILTERS", exact=True)).to_be_visible()
     expect(page.locator(".stat-block")).to_be_visible()
 
@@ -101,7 +99,6 @@ def test_counter_plural(page: Page, live_server):
     _make_observation(gbif_id=2, occurrence_id="2", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
 
@@ -114,7 +111,6 @@ def test_counter_singular(page: Page, live_server):
     _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".stat-count").get_by_text("1")).to_be_visible()
 
@@ -129,7 +125,6 @@ def test_empty_state_shown_when_no_results(page: Page, live_server):
 
     # Filter to sp2 which has no observations
     page.goto(live_server.url + f"/?status=all&speciesIds={sp2.pk}")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("No matching results found.")).to_be_visible()
     expect(
@@ -156,12 +151,10 @@ def test_species_filter_narrows_results(page: Page, live_server):
 
     # Unfiltered: 3 observations
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     expect(page.locator(".stat-count").get_by_text("3")).to_be_visible()
 
     # Filtered to sp1: 2 observations
     page.goto(live_server.url + f"/?status=all&speciesIds={sp1.pk}")
-    page.wait_for_load_state("networkidle")
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
 
 
@@ -172,13 +165,18 @@ def test_dataset_filter_narrows_results(page: Page, live_server):
     sp = Species.objects.create(name="Procambarus fallax", gbif_taxon_key=8879526)
     ds1 = Dataset.objects.create(name="Dataset A", gbif_dataset_key="key-a")
     ds2 = Dataset.objects.create(name="Dataset B", gbif_dataset_key="key-b")
-    _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis, dataset=ds1)
-    _make_observation(gbif_id=2, occurrence_id="2", species=sp, basis=basis, dataset=ds1)
-    _make_observation(gbif_id=3, occurrence_id="3", species=sp, basis=basis, dataset=ds2)
+    _make_observation(
+        gbif_id=1, occurrence_id="1", species=sp, basis=basis, dataset=ds1
+    )
+    _make_observation(
+        gbif_id=2, occurrence_id="2", species=sp, basis=basis, dataset=ds1
+    )
+    _make_observation(
+        gbif_id=3, occurrence_id="3", species=sp, basis=basis, dataset=ds2
+    )
 
     # Filtered to ds1: 2 observations
     page.goto(live_server.url + f"/?status=all&datasetIds={ds1.pk}")
-    page.wait_for_load_state("networkidle")
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
 
 
@@ -195,7 +193,6 @@ def test_table_view_shows_species_name(page: Page, live_server):
     _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     expect(page.get_by_text("Procambarus fallax")).to_be_visible()
@@ -211,7 +208,6 @@ def test_table_shows_verified_badge(page: Page, live_server):
     )
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     badge = page.locator(".badge-success")
@@ -229,7 +225,6 @@ def test_table_shows_unverified_badge(page: Page, live_server):
     )
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     badge = page.locator(".badge-danger")
@@ -250,7 +245,6 @@ def test_seen_column_shown_for_authenticated_user(page: Page, live_server):
 
     login(page, live_server.url, "testuser", "testpass123")
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     expect(page.get_by_role("columnheader", name="Viewed")).to_be_visible()
@@ -269,7 +263,6 @@ def test_table_row_click_opens_observation_drawer(page: Page, live_server):
     obs = _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     page.locator("tbody tr").first.click()
@@ -288,7 +281,6 @@ def test_deep_link_url_opens_drawer_on_load(page: Page, live_server):
     obs = _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + f"/?status=all&obs={obs.stable_id}")
-    page.wait_for_load_state("networkidle")
 
     drawer = page.locator('[data-pc-name="drawer"]')
     expect(drawer).to_be_visible()
@@ -310,15 +302,11 @@ def test_filter_state_preserved_when_drawer_closed(page: Page, live_server):
     obs = _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     # Navigate with both a species filter and the drawer open
-    page.goto(
-        live_server.url + f"/?status=all&speciesIds={sp.pk}&obs={obs.stable_id}"
-    )
-    page.wait_for_load_state("networkidle")
+    page.goto(live_server.url + f"/?status=all&speciesIds={sp.pk}&obs={obs.stable_id}")
     expect(page.locator('[data-pc-name="drawer"]')).to_be_visible()
 
     # Close the drawer via the X button
     page.get_by_role("button", name="Close").click()
-    page.wait_for_load_state("networkidle")
 
     # ?obs= is gone; speciesIds filter is still present
     sp_pk = sp.pk
@@ -354,7 +342,6 @@ def test_authenticated_user_sees_unseen_by_default(page: Page, live_server):
 
     login(page, live_server.url, "testuser", "testpass123")
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
 
@@ -378,7 +365,6 @@ def test_smart_status_default_falls_back_to_all(page: Page, live_server):
 
     login(page, live_server.url, "testuser", "testpass123")
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
 
     # Falls back to 'all': both observations are shown
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
@@ -399,7 +385,6 @@ def test_anonymous_user_sees_no_unseen_filter_badge(page: Page, live_server):
     _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
 
     # No "Not viewed" chip should be rendered
     expect(page.get_by_text("Not viewed", exact=True)).not_to_be_visible()
@@ -417,7 +402,6 @@ def test_anonymous_user_sees_all_observations_by_default(page: Page, live_server
     _make_observation(gbif_id=2, occurrence_id="2", species=sp, basis=basis)
 
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
 
     # Both observations are shown - no unseen pre-filter was applied
     expect(page.locator(".stat-count").get_by_text("2")).to_be_visible()
@@ -440,7 +424,6 @@ def test_authenticated_user_with_unseen_sees_unseen_badge(page: Page, live_serve
 
     login(page, live_server.url, "testuser", "testpass123")
     page.goto(live_server.url + "/")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_text("Not viewed", exact=True)).to_be_visible()
 
@@ -454,7 +437,6 @@ def test_authenticated_user_with_unseen_sees_unseen_badge(page: Page, live_serve
 def test_index_page_renders_sidebar(page: Page, live_server):
     """The index page loads with the sidebar filter panel visible."""
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     expect(page.get_by_text("FILTERS", exact=True)).to_be_visible()
 
 
@@ -466,7 +448,6 @@ def test_index_page_has_three_tabs(page: Page, live_server):
     _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_role("tab", name="Map")).to_be_visible()
     expect(page.get_by_role("tab", name="Timeline")).to_be_visible()
@@ -482,7 +463,6 @@ def test_index_observation_count_in_sidebar(page: Page, live_server):
     _make_observation(gbif_id=2, occurrence_id="2", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
 
     stat_block = page.locator(".stat-block")
     expect(stat_block).to_be_visible()
@@ -497,9 +477,7 @@ def test_index_timeline_tab_shows_histogram(page: Page, live_server):
     _make_observation(gbif_id=1, occurrence_id="1", species=sp, basis=basis)
 
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
 
     page.get_by_role("tab", name="Timeline").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".p-tabpanel:visible .histogram-svg")).to_be_visible()

--- a/dashboard/tests/playwright/test_navbar.py
+++ b/dashboard/tests/playwright/test_navbar.py
@@ -134,7 +134,9 @@ def test_navbar_red_dot_with_unseen_observations(page: Page, live_server):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_navbar_no_observations_dot_without_unseen_observations(page: Page, live_server):
+def test_navbar_no_observations_dot_without_unseen_observations(
+    page: Page, live_server
+):
     """No red dot is shown on 'My alerts' when the user has no unseen observations.
 
     Note: the news dot (.gbif-nav-dot on the 'What's new' item) is intentionally
@@ -158,7 +160,6 @@ def test_regular_user_cannot_access_admin_directly(page: Page, live_server):
     User.objects.create_user(username="testuser", password="testpass123")
     login(page, live_server.url, "testuser", "testpass123")
     page.goto(live_server.url + "/admin/")
-    page.wait_for_load_state("networkidle")
 
     # Django redirects to admin login and shows an "not authorized" message.
     expect(page).to_have_url(live_server.url + "/admin/login/?next=/admin/")
@@ -176,7 +177,6 @@ def test_superuser_can_access_admin_directly(page: Page, live_server):
     )
     login(page, live_server.url, "admin", "adminpass123")
     page.goto(live_server.url + "/admin/")
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/admin/")
     expect(page).to_have_title("Site administration | Django site admin")

--- a/dashboard/tests/playwright/test_profile_pages.py
+++ b/dashboard/tests/playwright/test_profile_pages.py
@@ -14,15 +14,15 @@ from dashboard.tests.playwright.helpers import login
 def test_about_site_page_renders(page: Page, live_server):
     """About site page loads and shows a heading."""
     page.goto(live_server.url + "/about-site")
-    page.wait_for_load_state("networkidle")
-    expect(page.get_by_role("heading", name="About this site", exact=False)).to_be_visible()
+    expect(
+        page.get_by_role("heading", name="About this site", exact=False)
+    ).to_be_visible()
 
 
 @pytest.mark.django_db(transaction=True)
 def test_api_docs_page_renders(page: Page, live_server):
     """The /api-docs hub shows its heading and links to the v2 docs + WFS."""
     page.goto(live_server.url + "/api-docs")
-    page.wait_for_load_state("networkidle")
     expect(page.get_by_role("heading", name="API", exact=False)).to_be_visible()
     expect(page.get_by_text("Open the API v2 docs", exact=False)).to_be_visible()
     # v2 is announced as the stable, supported public API.
@@ -41,7 +41,6 @@ def test_api_docs_page_renders(page: Page, live_server):
 def test_api_root_redirects_to_landing_page(page: Page, live_server):
     """Visiting bare /api/ lands the user on /api-docs."""
     page.goto(live_server.url + "/api/")
-    page.wait_for_load_state("networkidle")
     expect(page).to_have_url(live_server.url + "/api-docs")
 
 
@@ -54,7 +53,6 @@ def test_about_data_page_renders(page: Page, live_server):
         completed=True,
     )
     page.goto(live_server.url + "/about-data")
-    page.wait_for_load_state("networkidle")
     expect(page.get_by_text("Data import #", exact=False)).to_be_visible()
 
 
@@ -62,7 +60,6 @@ def test_about_data_page_renders(page: Page, live_server):
 def test_news_page_renders(page: Page, live_server):
     """News page loads and shows a heading."""
     page.goto(live_server.url + "/whats-new")
-    page.wait_for_load_state("networkidle")
     expect(page.get_by_role("heading", name="What's new", exact=False)).to_be_visible()
 
 
@@ -79,7 +76,6 @@ def test_profile_page_loads(page: Page, live_server):
 
     login(page, live_server.url, "profiletest", "pass1234")
     page.goto(live_server.url + "/profile")
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator("#p-firstname")).to_have_value("Alice")
     expect(page.locator("#p-email")).to_have_value("profile@t.com")
@@ -98,11 +94,9 @@ def test_profile_save_succeeds(page: Page, live_server):
 
     login(page, live_server.url, "profilesave", "pass1234")
     page.goto(live_server.url + "/profile")
-    page.wait_for_load_state("networkidle")
 
     page.locator("#p-firstname").fill("Charlie")
     page.get_by_role("button", name="Save profile").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(".p-toast")).to_be_visible()
     expect(page.locator(".p-toast")).to_contain_text("profile", ignore_case=True)
@@ -112,11 +106,12 @@ def test_profile_save_succeeds(page: Page, live_server):
 def test_api_token_create_and_revoke_via_ui(page: Page, live_server):
     """Dedicated /api-tokens page: create (raw value + sample curl shown once) then revoke."""
     User = get_user_model()
-    User.objects.create_user(username="toktester", password="pass1234", email="tt@t.com")
+    User.objects.create_user(
+        username="toktester", password="pass1234", email="tt@t.com"
+    )
 
     login(page, live_server.url, "toktester", "pass1234")
     page.goto(live_server.url + "/api-tokens")
-    page.wait_for_load_state("networkidle")
 
     expect(page.get_by_role("heading", name="API tokens")).to_be_visible()
     expect(page.get_by_text("You don't have any API tokens yet.")).to_be_visible()
@@ -154,11 +149,9 @@ def test_delete_account_confirmed(page: Page, live_server):
 
     login(page, live_server.url, "todel", "pass1234")
     page.goto(live_server.url + "/profile")
-    page.wait_for_load_state("networkidle")
 
     page.locator("[data-testid='delete-account-btn']").click()
     page.get_by_role("button", name="Yes, I'm sure").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page).to_have_url(live_server.url + "/accounts/signin/")
     assert not User.objects.filter(username="todel").exists()
@@ -172,7 +165,6 @@ def test_delete_account_cancelled(page: Page, live_server):
 
     login(page, live_server.url, "tokeep", "pass1234")
     page.goto(live_server.url + "/profile")
-    page.wait_for_load_state("networkidle")
 
     page.locator("[data-testid='delete-account-btn']").click()
     page.get_by_role("button", name="Cancel").click()

--- a/dashboard/tests/playwright/test_profile_pages.py
+++ b/dashboard/tests/playwright/test_profile_pages.py
@@ -95,7 +95,11 @@ def test_profile_save_succeeds(page: Page, live_server):
     login(page, live_server.url, "profilesave", "pass1234")
     page.goto(live_server.url + "/profile")
 
-    page.locator("#p-firstname").fill("Charlie")
+    first_name = page.locator("#p-firstname")
+    # Wait for the profile data to load into the form before editing; otherwise
+    # the late GET clobbers the typed value.
+    expect(first_name).to_have_value("Bob")
+    first_name.fill("Charlie")
     page.get_by_role("button", name="Save profile").click()
 
     expect(page.locator(".p-toast")).to_be_visible()

--- a/dashboard/tests/playwright/test_species_image_tooltip.py
+++ b/dashboard/tests/playwright/test_species_image_tooltip.py
@@ -8,7 +8,11 @@ from django.utils import timezone
 from playwright.sync_api import Page, expect
 
 from dashboard.models import (
-    BasisOfRecord, DataImport, Dataset, Observation, Species,
+    BasisOfRecord,
+    DataImport,
+    Dataset,
+    Observation,
+    Species,
 )
 
 
@@ -18,6 +22,7 @@ def _solid_png(width: int, height: int, rgb=(60, 140, 60)) -> bytes:
     A genuinely wide image is required to exercise the tooltip's overflow
     handling - a 1x1 stub would never reach the CSS size limits.
     """
+
     def chunk(typ: bytes, data: bytes) -> bytes:
         body = typ + data
         return (
@@ -45,14 +50,20 @@ _WIDE_PNG = _solid_png(400, 260)
 def test_species_tooltip_shows_image(page: Page, live_server):
     di = DataImport.objects.create(start=timezone.now())
     sp = Species.objects.create(
-        name="Vulpes vulpes", gbif_taxon_key=999040,
+        name="Vulpes vulpes",
+        gbif_taxon_key=999040,
         image_url="https://example.org/fox.jpg",
-        image_attribution="Jane Doe", image_license="CC BY-SA 4.0",
+        image_attribution="Jane Doe",
+        image_license="CC BY-SA 4.0",
         image_source_type=Species.ImageSourceType.WIKIPEDIA,
     )
     Observation.objects.create(
-        gbif_id=42, occurrence_id="42", species=sp,
-        date=datetime.date.today(), data_import=di, initial_data_import=di,
+        gbif_id=42,
+        occurrence_id="42",
+        species=sp,
+        date=datetime.date.today(),
+        data_import=di,
+        initial_data_import=di,
         source_dataset=Dataset.objects.create(name="D", gbif_dataset_key="k"),
         location=Point(5.09, 50.48, srid=4326),
         basis_of_record=BasisOfRecord.objects.create(name="HUMAN_OBSERVATION"),
@@ -69,10 +80,8 @@ def test_species_tooltip_shows_image(page: Page, live_server):
 
     # Navigate to index with status=all so the observation is visible
     page.goto(live_server.url + "/?status=all")
-    page.wait_for_load_state("networkidle")
     # Switch to table view where SpeciesName renders
     page.get_by_role("tab", name="Table").click()
-    page.wait_for_load_state("networkidle")
     # Find the species-name element and hover it
     name = page.locator(".species-name", has_text="Vulpes vulpes").first
     name.hover()

--- a/dashboard/tests/playwright/test_species_name_toggle.py
+++ b/dashboard/tests/playwright/test_species_name_toggle.py
@@ -73,7 +73,6 @@ def two_observations(db):
 
 def _switch_to_table_view(page: Page) -> None:
     page.get_by_role("tab", name="Table").click()
-    page.wait_for_load_state("networkidle")
 
 
 def _click_toggle(page: Page) -> None:
@@ -85,7 +84,6 @@ def _click_toggle(page: Page) -> None:
 def test_default_mode_shows_scientific(live_server, page: Page, two_observations):
     """With no cookie, the table shows italicised scientific names."""
     page.goto(f"{live_server.url}/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     em = page.locator("em", has_text="Anas platyrhynchos").first
@@ -96,13 +94,11 @@ def test_default_mode_shows_scientific(live_server, page: Page, two_observations
 def test_toggle_switches_to_vernacular(live_server, page: Page, two_observations):
     """Clicking the navbar toggle flips the rendering to vernacular."""
     page.goto(f"{live_server.url}/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     expect(page.locator("em", has_text="Anas platyrhynchos").first).to_be_visible()
 
     _click_toggle(page)
-    page.wait_for_load_state("networkidle")
 
     # Species with vernacular shows the common name (no em)
     expect(page.locator("text=Mallard").first).to_be_visible()
@@ -115,15 +111,12 @@ def test_toggle_switches_to_vernacular(live_server, page: Page, two_observations
 def test_preference_persists_across_reload(live_server, page: Page, two_observations):
     """Setting vernacular mode persists after a full page reload."""
     page.goto(f"{live_server.url}/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     _click_toggle(page)
-    page.wait_for_load_state("networkidle")
     expect(page.locator("text=Mallard").first).to_be_visible()
 
     page.reload()
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     expect(page.locator("text=Mallard").first).to_be_visible()
@@ -135,13 +128,11 @@ def test_sort_re_issues_when_preference_changes(
 ):
     """While sorted on species, flipping the toggle re-fetches with the new orderBy."""
     page.goto(f"{live_server.url}/?status=all")
-    page.wait_for_load_state("networkidle")
     _switch_to_table_view(page)
 
     # Click the Species column header to sort by it
     species_header = page.get_by_role("columnheader", name="Species")
     species_header.click()
-    page.wait_for_load_state("networkidle")
 
     with page.expect_response(lambda r: "orderBy=vernacularName" in r.url) as resp_info:
         _click_toggle(page)


### PR DESCRIPTION
## Why

The Playwright suite intermittently fails on `test_deep_link_url_opens_drawer_on_load` (and its sibling `test_filter_state_preserved_when_drawer_closed`) with `TimeoutError: Timeout 30000ms exceeded` on `page.wait_for_load_state("networkidle")`. Seen twice on recent CI (once it re-ran green, once red again), so it's a genuine flake, not a code break.

**Root cause:** `networkidle` only resolves after 500 ms of zero network traffic (cap 30 s). The index page mounts an OpenLayers map that streams tiles and fires background API calls, so on the heaviest flows - a fresh `goto` that also opens the observation drawer - the network never goes quiet within 30 s and the wait times out **even though the drawer opened fine**. Playwright officially discourages `networkidle` for exactly this reason. The waits were also redundant: each is immediately followed by a web-first `expect(...)` assertion or an auto-waiting action that already synchronises.

## What changed

- **Removed all ~120 `wait_for_load_state("networkidle")` calls** across the 10 Playwright test files, plus the `wait_until="networkidle"` in the sign-in helper (`wait_for_url` now defaults to `load`, and it already gates on the URL predicate).
- **Raised the default assertion timeout to 15 s** via `expect.set_options(timeout=15_000)` in the Playwright conftest, so a cold SPA boot in CI (Vue mount + first data fetch) has headroom now that the network wait is gone. Actions keep Playwright's 30 s default.
- **`test_alert_detail_drawer_refreshes_list_and_sidebar`**: this one `networkidle` was load-bearing - it let the `mark-as-viewed` POST finish before the drawer was closed. Replaced with a deterministic `page.expect_response(".../mark-as-viewed/" POST)` wrapping the drawer-open click, so the POST is guaranteed complete before Escape (and the close-triggered refresh reads the updated seen state).

## Safety of the removals

I audited every non-auto-waiting read in the suite (`page.url`, `.count()`, `.input_value()`, `.inner_text()`): each is already gated by a preceding `expect(...).to_be_visible()`, so none relied on the removed `networkidle`.

## Verification note

I could **not** run the Playwright suite locally - `pytest_sessionstart` runs `npm run vite-build`, which needs Node 20.19+ (this machine has Node 19). `black --check` and `mypy` pass on the changed files. Please let CI exercise it; given the flake is intermittent, a couple of green runs are worth confirming before merge. I'll re-run CI a few times.